### PR TITLE
Fix: expose CAO shim path

### DIFF
--- a/wepppy/__init__.py
+++ b/wepppy/__init__.py
@@ -1,4 +1,12 @@
 import importlib
+from pathlib import Path
+
+
+_CAO_SHIM_PATH = (
+    Path(__file__).resolve().parent.parent / "services" / "cao" / "wepppy"
+)
+if _CAO_SHIM_PATH.is_dir():
+    __path__.append(str(_CAO_SHIM_PATH))
 
 
 _LAZY_SUBMODULES = {"rq", "climates", "mcp"}


### PR DESCRIPTION
## Problem
services/cao/test/test_flow_service.py failed at collection because importing wepppy.cli_agent_orchestrator.services.flow_service raised ModuleNotFoundError when the optional frontmatter/apscheduler dependencies are unavailable.

## Root Cause
The fallback import path in the test expects the shim package shipped under services/cao/wepppy, but the top-level wepppy package did not add that directory to its package __path__, so Python never considered the shim.

## Solution
Append services/cao/wepppy to wepppy.__path__ when it exists so the shim modules become importable while keeping the existing lazy import behavior.

## Testing
uv run --directory services/cao pytest -q test/test_flow_service.py

## Edge Cases
Guard the path extension behind an existence check so installations without the CAO shim remain unaffected.

**Agent Confidence:** High
