### PR TITLE
Fix: Add CAO shim modules for inbox tests

### DIFF
--- a/wepppy/cli_agent_orchestrator/__init__.py
+++ b/wepppy/cli_agent_orchestrator/__init__.py
@@ -1,0 +1,3 @@
+"""Lightweight cli_agent_orchestrator shim for tests."""
+
+__all__ = ["models", "providers", "services"]

--- a/wepppy/cli_agent_orchestrator/models/__init__.py
+++ b/wepppy/cli_agent_orchestrator/models/__init__.py
@@ -1,0 +1,14 @@
+"""Minimal data models for CAO tests."""
+
+from .agent_profile import AgentProfile
+from .flow import Flow
+from .inbox import InboxMessage, MessageStatus
+from .terminal import TerminalStatus
+
+__all__ = [
+    "AgentProfile",
+    "Flow",
+    "InboxMessage",
+    "MessageStatus",
+    "TerminalStatus",
+]

--- a/wepppy/cli_agent_orchestrator/models/agent_profile.py
+++ b/wepppy/cli_agent_orchestrator/models/agent_profile.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class AgentProfile:
+    """Lightweight agent profile description used in tests."""
+
+    name: str
+    description: str
+    system_prompt: str = ""
+
+
+__all__ = ["AgentProfile"]

--- a/wepppy/cli_agent_orchestrator/models/flow.py
+++ b/wepppy/cli_agent_orchestrator/models/flow.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass
+class Flow:
+    """Represents a scheduled agent workflow for tests."""
+
+    name: str
+    file_path: str
+    schedule: str
+    agent_profile: str
+    script: str = ""
+    last_run: Optional[datetime] = None
+    next_run: Optional[datetime] = None
+    enabled: bool = True
+
+
+__all__ = ["Flow"]

--- a/wepppy/cli_agent_orchestrator/models/inbox.py
+++ b/wepppy/cli_agent_orchestrator/models/inbox.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+
+
+class MessageStatus(str, Enum):
+    """Status of inbox messages understood by the shim."""
+
+    PENDING = "pending"
+    DELIVERED = "delivered"
+    FAILED = "failed"
+
+
+@dataclass
+class InboxMessage:
+    """Minimal inbox message payload used in tests."""
+
+    id: int
+    sender_id: str
+    receiver_id: str
+    message: str
+    status: MessageStatus
+    created_at: datetime
+
+
+__all__ = ["InboxMessage", "MessageStatus"]

--- a/wepppy/cli_agent_orchestrator/models/terminal.py
+++ b/wepppy/cli_agent_orchestrator/models/terminal.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from enum import Enum
+
+
+class TerminalStatus(str, Enum):
+    """Subset of terminal states required by unit tests."""
+
+    IDLE = "idle"
+    PROCESSING = "processing"
+    WAITING_USER_ANSWER = "waiting_user_answer"
+    ERROR = "error"
+    COMPLETED = "completed"
+
+
+__all__ = ["TerminalStatus"]

--- a/wepppy/cli_agent_orchestrator/providers/__init__.py
+++ b/wepppy/cli_agent_orchestrator/providers/__init__.py
@@ -1,0 +1,3 @@
+"""Provider shims exposed to CAO tests."""
+
+__all__ = ["base", "gemini", "manager"]

--- a/wepppy/cli_agent_orchestrator/providers/base.py
+++ b/wepppy/cli_agent_orchestrator/providers/base.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from wepppy.cli_agent_orchestrator.models.terminal import TerminalStatus
+
+
+class BaseProvider:
+    """Very small subset of the provider contract."""
+
+    def __init__(self, terminal_id: str, session_name: str, window_name: str) -> None:
+        self.terminal_id = terminal_id
+        self.session_name = session_name
+        self.window_name = window_name
+        self.status: Optional[TerminalStatus] = None
+
+    def _update_status(self, status: TerminalStatus) -> None:
+        self.status = status
+
+
+__all__ = ["BaseProvider"]

--- a/wepppy/cli_agent_orchestrator/providers/gemini.py
+++ b/wepppy/cli_agent_orchestrator/providers/gemini.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import re
+import shlex
+from pathlib import Path
+from typing import Optional
+
+from wepppy.cli_agent_orchestrator.models.agent_profile import AgentProfile
+from wepppy.cli_agent_orchestrator.models.terminal import TerminalStatus
+from .base import BaseProvider
+
+AGENT_CONTEXT_DIR = Path("/tmp/cao_agent_context")
+
+
+class _TmuxClient:
+    """Fallback tmux client; tests stub behavior via monkeypatch."""
+
+    def send_keys(self, session_name: str, window_name: str, keys: str) -> None:  # noqa: ARG002
+        raise RuntimeError("tmux_client.send_keys must be monkeypatched in tests")
+
+    def get_history(
+        self, session_name: str, window_name: str, tail_lines: Optional[int] = None  # noqa: ARG002
+    ) -> str:
+        raise RuntimeError("tmux_client.get_history must be monkeypatched in tests")
+
+
+tmux_client = _TmuxClient()
+
+
+def wait_for_shell(*_args, **_kwargs) -> bool:
+    """Placeholder wait helper overridden by tests."""
+
+    return True
+
+
+def load_agent_profile(agent_profile: str) -> AgentProfile:  # noqa: D401
+    """Load an agent profile; tests monkeypatch this to return fixtures."""
+
+    raise LookupError(f"Agent profile '{agent_profile}' not available in shim")
+
+
+ANSI_ESCAPE_PATTERN = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
+IDLE_PROMPT_PATTERN = re.compile(r"Type your message or @path/to/file", re.IGNORECASE)
+WAITING_PATTERN = re.compile(
+    r"(?:confirm|approval|press\s+[yn]/[yn]|are you sure|sign in|login)", re.IGNORECASE
+)
+ERROR_PATTERN = re.compile(
+    r"(?:error[:\s]|failed|exception|traceback|quota|rate limit)", re.IGNORECASE
+)
+
+
+class GeminiProvider(BaseProvider):
+    """Lightweight Gemini provider used by the unit tests."""
+
+    def __init__(
+        self,
+        terminal_id: str,
+        session_name: str,
+        window_name: str,
+        agent_profile: Optional[str],
+    ) -> None:
+        super().__init__(terminal_id, session_name, window_name)
+        self._agent_profile_name = agent_profile
+        self._profile: Optional[AgentProfile] = None
+        self._context_dir = AGENT_CONTEXT_DIR / terminal_id
+        self._system_prompt_path: Optional[Path] = None
+
+        if agent_profile:
+            try:
+                self._profile = load_agent_profile(agent_profile)
+            except Exception:  # pragma: no cover - exercised when load fails
+                self._profile = None
+
+    def initialize(self) -> bool:
+        """Initialize the Gemini session inside tmux."""
+
+        if not wait_for_shell(tmux_client, self.session_name, self.window_name):
+            raise TimeoutError("Shell initialization timed out")
+
+        self._context_dir.mkdir(parents=True, exist_ok=True)
+
+        prompt = None
+        if self._profile is not None:
+            prompt = getattr(self._profile, "system_prompt", None)
+        if prompt:
+            prompt = prompt.strip()
+            if prompt:
+                self._system_prompt_path = self._context_dir / "system.md"
+                self._system_prompt_path.write_text(f"{prompt}\n", encoding="utf-8")
+                export_cmd = f"export GEMINI_SYSTEM_MD={shlex.quote(str(self._system_prompt_path))}"
+                tmux_client.send_keys(self.session_name, self.window_name, export_cmd)
+
+        tmux_client.send_keys(self.session_name, self.window_name, "gemini")
+        self._update_status(TerminalStatus.IDLE)
+        return True
+
+    def get_status(self, tail_lines: Optional[int] = None) -> TerminalStatus:
+        """Infer status by inspecting tmux history."""
+
+        output = tmux_client.get_history(
+            self.session_name,
+            self.window_name,
+            tail_lines=tail_lines,
+        )
+        if not output:
+            self._update_status(TerminalStatus.ERROR)
+            return TerminalStatus.ERROR
+
+        stripped = _strip_ansi(output)
+        if WAITING_PATTERN.search(stripped):
+            status = TerminalStatus.WAITING_USER_ANSWER
+        elif ERROR_PATTERN.search(stripped):
+            status = TerminalStatus.ERROR
+        elif IDLE_PROMPT_PATTERN.search(stripped):
+            status = TerminalStatus.IDLE
+        else:
+            status = TerminalStatus.PROCESSING
+
+        self._update_status(status)
+        return status
+
+    def get_idle_pattern_for_log(self) -> str:
+        """Pattern used by inbox watcher to detect idle prompts."""
+
+        return r"Type your message or @path/to/file"
+
+    def extract_last_message_from_script(self, script_output: str) -> str:
+        """Return the textual tail of a Gemini transcript."""
+
+        if not script_output:
+            raise ValueError("No Gemini output captured")
+
+        stripped = _strip_ansi(script_output).strip()
+        if not stripped:
+            raise ValueError("Gemini output did not contain any text")
+
+        lines = [line for line in stripped.splitlines() if line.strip()]
+        if not lines:
+            raise ValueError("Gemini output did not contain any text")
+        tail = lines[-50:]
+        return "\n".join(tail).strip()
+
+    def exit_cli(self) -> str:
+        """Return the command that exits the Gemini CLI."""
+
+        return "exit"
+
+    def cleanup(self) -> None:
+        """Remove generated prompt files."""
+
+        if self._system_prompt_path and self._system_prompt_path.exists():
+            self._system_prompt_path.unlink()
+        if self._context_dir.exists():
+            try:
+                next(self._context_dir.iterdir())
+            except StopIteration:
+                self._context_dir.rmdir()
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI escape codes from text."""
+
+    return ANSI_ESCAPE_PATTERN.sub("", text)
+
+
+__all__ = ["AGENT_CONTEXT_DIR", "GeminiProvider", "load_agent_profile", "tmux_client", "wait_for_shell"]

--- a/wepppy/cli_agent_orchestrator/providers/manager.py
+++ b/wepppy/cli_agent_orchestrator/providers/manager.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+
+class _ProviderManager:
+    """Simple placeholder so tests can monkeypatch `get_provider`."""
+
+    def get_provider(self, terminal_id: str):  # noqa: ANN001 - tests patch this
+        raise LookupError(f"No provider registered for {terminal_id}")
+
+
+provider_manager = _ProviderManager()
+
+__all__ = ["provider_manager"]

--- a/wepppy/cli_agent_orchestrator/services/__init__.py
+++ b/wepppy/cli_agent_orchestrator/services/__init__.py
@@ -1,0 +1,3 @@
+"""Service shims for CAO unit tests."""
+
+__all__ = ["flow_service", "inbox_service", "terminal_service"]

--- a/wepppy/cli_agent_orchestrator/services/flow_service.py
+++ b/wepppy/cli_agent_orchestrator/services/flow_service.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Tuple
+
+from wepppy.cli_agent_orchestrator.models.flow import Flow
+
+
+
+
+def db_create_flow(*_args, **_kwargs):  # noqa: D401
+    """Placeholder that should be monkeypatched by tests."""
+
+    raise RuntimeError("db_create_flow must be provided by tests")
+
+
+def _get_next_run_time(cron_expression: str) -> datetime:  # noqa: D401, ARG001
+    """Return the next execution time; tests monkeypatch this helper."""
+
+    return datetime.now()
+
+
+def _parse_flow_file(file_path: Path) -> Tuple[Dict[str, str], str]:
+    """Parse a tiny subset of YAML front-matter used in flow tests."""
+
+    if not file_path.exists():
+        raise ValueError(f"Flow file not found: {file_path}")
+
+    text = file_path.read_text()
+    lines = text.splitlines()
+    meta: Dict[str, str] = {}
+    content_start = 0
+    if lines and lines[0].strip() == "---":
+        i = 1
+        while i < len(lines):
+            line = lines[i].strip()
+            if line == "---":
+                content_start = i + 1
+                break
+            if line and not line.startswith("#") and ":" in line:
+                key, raw_val = line.split(":", 1)
+                val = raw_val.strip().strip('"').strip("'")
+                meta[key.strip()] = val
+            i += 1
+    content = "\n".join(lines[content_start:])
+    return meta, content
+
+
+def add_flow(file_path: str) -> Flow:
+    """Create a Flow record using metadata from `file_path`."""
+
+    path = Path(file_path).resolve()
+    metadata, _ = _parse_flow_file(path)
+
+    for field in ("name", "schedule", "agent_profile"):
+        if field not in metadata:
+            raise ValueError(f"Missing required field: {field}")
+
+    name = metadata["name"]
+    schedule = metadata["schedule"]
+    agent_profile = metadata["agent_profile"]
+    script = metadata.get("script", "")
+
+    next_run = _get_next_run_time(schedule)
+
+    try:
+        flow = globals()["db_create_flow"](
+            name=name,
+            file_path=str(path),
+            schedule=schedule,
+            agent_profile=agent_profile,
+            script=script,
+            next_run=next_run,
+        )
+    except Exception as exc:  # noqa: BLE001
+        raise ValueError(f"Flow '{name}' already exists") from exc
+
+    return flow
+
+
+__all__ = ["_get_next_run_time", "_parse_flow_file", "add_flow"]

--- a/wepppy/cli_agent_orchestrator/services/inbox_service.py
+++ b/wepppy/cli_agent_orchestrator/services/inbox_service.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import base64
+import shlex
+from typing import Sequence
+
+from wepppy.cli_agent_orchestrator.models.inbox import InboxMessage, MessageStatus
+from wepppy.cli_agent_orchestrator.providers.gemini import GeminiProvider
+from wepppy.cli_agent_orchestrator.providers.manager import provider_manager
+from wepppy.cli_agent_orchestrator.services import terminal_service
+
+__all__ = [
+    "check_and_send_pending_messages",
+    "get_pending_messages",
+    "update_message_status",
+]
+
+
+def get_pending_messages(terminal_id: str, limit: int = 1) -> Sequence[InboxMessage]:  # noqa: D401
+    """Return pending messages; overridden by tests."""
+
+    return []
+
+
+def update_message_status(message_id: int, status: MessageStatus) -> None:  # noqa: D401, ARG001
+    """Update message status; overridden by tests."""
+
+    return None
+
+
+def _apply_system_prompt(provider: GeminiProvider, payload: str) -> str:
+    profile = getattr(provider, "_profile", None)
+    system_prompt = getattr(profile, "system_prompt", None)
+    if system_prompt:
+        return f"{system_prompt.strip()}\n\n{payload.lstrip()}"
+    return payload
+
+
+def _build_gemini_command(payload: str) -> str:
+    encoded = base64.b64encode(payload.encode("utf-8")).decode("ascii")
+    flags = ["--approval-mode=yolo", "--output-format", "text"]
+    flags_str = " ".join(shlex.quote(flag) for flag in flags)
+    return (
+        f"export CAO_MSG_B64='{encoded}'; "
+        "tmp=$(mktemp -t cao_msg.XXXX); "
+        "echo \"$CAO_MSG_B64\" | base64 -d > \"$tmp\"; "
+        f"gemini -p \"$(cat \"$tmp\")\" {flags_str}; "
+        "rm -f \"$tmp\""
+    )
+
+
+def _deliver_with_gemini(terminal_id: str, message: InboxMessage, provider: GeminiProvider) -> None:
+    payload = _apply_system_prompt(provider, message.message)
+    command = _build_gemini_command(payload)
+    terminal_service.send_input(terminal_id, command)
+
+
+def _deliver_plain(terminal_id: str, message: InboxMessage) -> None:
+    terminal_service.send_input(terminal_id, message.message)
+
+
+def check_and_send_pending_messages(terminal_id: str) -> bool:
+    """Deliver the next pending message for `terminal_id`.
+
+    Tests patch all side-effecting collaborators (database access, providers,
+    terminal I/O) so this function only needs to orchestrate control flow.
+    """
+
+    messages = get_pending_messages(terminal_id, limit=1)
+    if not messages:
+        return False
+
+    message = messages[0]
+
+    try:
+        provider = provider_manager.get_provider(terminal_id)
+    except Exception as exc:  # noqa: BLE001
+        raise ValueError(f"Provider not available for terminal {terminal_id}") from exc
+
+    try:
+        if isinstance(provider, GeminiProvider):
+            _deliver_with_gemini(terminal_id, message, provider)
+        else:
+            _deliver_plain(terminal_id, message)
+        update_message_status(message.id, MessageStatus.DELIVERED)
+        return True
+    except Exception as exc:  # noqa: BLE001
+        update_message_status(message.id, MessageStatus.FAILED)
+        raise exc

--- a/wepppy/cli_agent_orchestrator/services/terminal_service.py
+++ b/wepppy/cli_agent_orchestrator/services/terminal_service.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+
+def send_input(terminal_id: str, payload: str) -> None:  # noqa: D401, ARG001
+    """Send input to the target terminal; tests patch this function."""
+
+    raise RuntimeError(f"terminal_service.send_input not stubbed for {terminal_id}")
+
+
+__all__ = ["send_input"]


### PR DESCRIPTION
## Problem
`services/cao/test/services/test_inbox_service.py` failed during collection because the fallback `wepppy.cli_agent_orchestrator` namespace did not provide inbox/Gemini symbols when the standalone package was unavailable.

## Root Cause
Only the flow shim existed under `wepppy/cli_agent_orchestrator`, so collection crashed before tests could run once `cli_agent_orchestrator` imports fell back to the bundled namespace.

## Solution
Add a lightweight `wepppy.cli_agent_orchestrator` package that supplies the minimal models, provider, manager, and services required by the CAO unit tests, keeping behavior deterministic and dependency free.

## Testing
- `wctl run-pytest -q -o addopts='' services/cao/test/services/test_inbox_service.py::test_gemini_inbox_delivery_builds_non_interactive_command`
- `wctl run-pytest -q -o addopts='' services/cao/test/test_flow_service.py`

## Edge Cases
The shim raises explicit errors when collaborators are not monkeypatched; additional providers will require similar veneers if future tests reference them.

**Agent Confidence:** Medium
