### PR TITLE
Fix CAO tests when optional deps missing

### DIFF
--- a/services/cao/src/cli_agent_orchestrator/utils/agent_profiles.py
+++ b/services/cao/src/cli_agent_orchestrator/utils/agent_profiles.py
@@ -1,8 +1,20 @@
 """Agent profile utilities."""
 
-import frontmatter
 from importlib import resources
 from pathlib import Path
+
+try:
+    import frontmatter  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - exercised in minimal test envs
+    class _MissingFrontMatter:
+        def loads(self, *_args, **_kwargs):
+            raise RuntimeError(
+                "The 'frontmatter' package is required to parse agent profiles. "
+                "Install python-frontmatter or monkeypatch load_agent_profile in tests."
+            )
+
+    frontmatter = _MissingFrontMatter()  # type: ignore[assignment]
+
 from cli_agent_orchestrator.models.agent_profile import AgentProfile
 from cli_agent_orchestrator.constants import LOCAL_AGENT_STORE_DIR
 

--- a/wepppy/cli_agent_orchestrator/__init__.py
+++ b/wepppy/cli_agent_orchestrator/__init__.py
@@ -1,0 +1,53 @@
+"""Compatibility bridge for the CLI Agent Orchestrator package.
+
+Tests and legacy scripts import ``wepppy.cli_agent_orchestrator`` while the
+real implementation lives in ``services/cao/src`` (or an installed wheel).
+This module proxies those imports so both environments work without modifying
+``PYTHONPATH``.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from pathlib import Path
+import sys
+
+_PACKAGE_NAME = "cli_agent_orchestrator"
+
+
+def _ensure_src_on_path() -> None:
+    """Ensure the editable source tree is importable during dev runs."""
+    src_root = Path(__file__).resolve().parents[2] / "services" / "cao" / "src"
+    if not src_root.exists():
+        return
+
+    src_str = str(src_root)
+    if src_str not in sys.path:
+        sys.path.append(src_str)
+
+
+def _load_package():
+    try:
+        return import_module(_PACKAGE_NAME)
+    except ModuleNotFoundError as exc:
+        if exc.name != _PACKAGE_NAME:
+            raise
+
+        _ensure_src_on_path()
+        return import_module(_PACKAGE_NAME)
+
+
+_package = _load_package()
+
+# Mirror the real package metadata and submodule search path.
+__all__ = getattr(_package, "__all__", [])
+__doc__ = getattr(_package, "__doc__", __doc__)
+__path__ = list(getattr(_package, "__path__", []))
+
+
+def __getattr__(name: str):
+    return getattr(_package, name)
+
+
+def __dir__():
+    return sorted(set(globals()) | set(dir(_package)))


### PR DESCRIPTION
## Problem
pytest collection for the Gemini provider and inbox service fails when optional dependencies (cli_agent_orchestrator, libtmux, watchdog, python-frontmatter) are unavailable and the constants module tries to create /.wepppy.

## Root Cause
The CAO modules import optional dependencies at import time and eagerly create directories under Path.home(), which resolves to '/', so missing packages or permissions abort module import during test collection.

## Solution
Add a compatibility shim for wepppy.cli_agent_orchestrator, guard optional imports for libtmux/watchdog/frontmatter, fall back to writable CAO/Codex directories, and rely on provider class names instead of isinstance to skip Gemini status gating.

## Testing
- wctl run-pytest -q services/cao/test/providers/test_gemini_provider.py
- wctl run-pytest -q services/cao/test/services/test_inbox_service.py

## Edge Cases
Missing optional dependencies now surface helpful runtime errors while allowing tests to monkeypatch.

**Agent Confidence:** high