### PR TITLE
Fix: Skip soil build test without HydroGrids data

### DIFF
--- a/wepppy/eu/soils/tests/soil_build_test.py
+++ b/wepppy/eu/soils/tests/soil_build_test.py
@@ -4,10 +4,15 @@ import pytest
 
 ESDAC_RASTER_DIR = "/geodata/eu/ESDAC_ESDB_rasters"
 ESDAC_STU_DIR = "/geodata/eu/ESDAC_STU_EU_Layers"
+EU_SOIL_HYDROGRIDS_SAMPLE = "/geodata/eu/eusoilhydrogrids/KS_sl1/KS_sl1.tif"
 
 pytestmark = pytest.mark.skipif(
-    not (os.path.isdir(ESDAC_RASTER_DIR) and os.path.isdir(ESDAC_STU_DIR)),
-    reason="ESDAC rasters unavailable",
+    not (
+        os.path.isdir(ESDAC_RASTER_DIR)
+        and os.path.isdir(ESDAC_STU_DIR)
+        and os.path.exists(EU_SOIL_HYDROGRIDS_SAMPLE)
+    ),
+    reason="ESDAC rasters or EU Soil HydroGrids data unavailable",
 )
 
 


### PR DESCRIPTION
## Problem
`wepppy/eu/soils/tests/soil_build_test.py::test_collection_error` fails on environments where the EU Soil HydroGrids rasters are not available, because `SoilHydroGrids` asserts the files exist during initialization.

## Root Cause
The test only skips when the ESDAC raster directories are missing and does not account for the EU Soil HydroGrids data that `ESDAC.build_wepp_soil` now requires.

## Solution
Extend the skip guard to also ensure a representative EU Soil HydroGrids GeoTIFF is present before running the test.

## Testing
`wctl run-pytest -q wepppy/eu/soils/tests/soil_build_test.py::test_collection_error`

## Edge Cases
When the HydroGrids data is available the test still runs normally, so environments with the datasets keep coverage of the integration path.

**Agent Confidence:** High
