### PR TITLE
Fix: align run_wepp TaskEnum stub

### DIFF
--- a/tests/weppcloud/routes/test_wepp_bp.py
+++ b/tests/weppcloud/routes/test_wepp_bp.py
@@ -247,6 +247,7 @@ def run_wepp_api_client(
     class DummyTaskEnum:
         run_wepp_hillslopes = "run_wepp_hillslopes"
         run_wepp_watershed = "run_wepp_watershed"
+        run_omni_scenarios = "run_omni_scenarios"
 
     monkeypatch.setattr(wepp_rq_module, "TaskEnum", DummyTaskEnum)
 
@@ -322,7 +323,7 @@ def test_run_wepp_accepts_json_payload(run_wepp_api_client):
 
     env = ctx["env"]
     prep = env.redis_prep_class.getInstance(run_dir)
-    assert prep.removed == ["run_wepp_hillslopes", "run_wepp_watershed"]
+    assert prep.removed == ["run_wepp_hillslopes", "run_wepp_watershed", "run_omni_scenarios"]
     assert prep.job_history == [("run_wepp_rq", "job-123")]
 
     queue_call = env.recorder.queue_calls[0]


### PR DESCRIPTION
## Problem
`tests/weppcloud/routes/test_wepp_bp.py::test_run_wepp_accepts_json_payload` failed because the JSON route now resets `TaskEnum.run_omni_scenarios`, but the test double did not expose that attribute. The prep removal assertion was also stale.

## Root Cause
The TaskEnum stub inside `run_wepp_api_client` only defined the hillslope and watershed members. When the route started clearing the Omni timestamp, the test raised an AttributeError and the recorded removal list no longer matched assertions.

## Solution
Extend the DummyTaskEnum with `run_omni_scenarios` and update the expectation to include the extra removal so the stub mirrors the production enum.

## Testing
- `ssh nuc2.local "cd /workdir/wepppy && wctl run-pytest -q tests/weppcloud/routes/test_wepp_bp.py::test_run_wepp_accepts_json_payload"`

## Edge Cases
Keeping the test stub in sync with the production enum ensures future TaskEnum removals are exercised by the fixture and avoids AttributeErrors in other payload variations.

**Agent Confidence:** High