### PR TITLE
Fix: pad DSS export dates to four-digit years

### DIFF
--- a/wepppy/wepp/interchange/dss_dates.py
+++ b/wepppy/wepp/interchange/dss_dates.py
@@ -63,4 +63,6 @@ def format_dss_date(value: date | None) -> str | None:
 
     if value is None:
         return None
-    return value.strftime(DATE_DISPLAY_FORMAT)
+    # ``strftime`` may omit leading zeros for years prior to 1000 on some
+    # platforms; build the string manually to guarantee ``MM/DD/YYYY`` output.
+    return f"{value.month:02d}/{value.day:02d}/{value.year:04d}"


### PR DESCRIPTION
## Problem
`tests/weppcloud/routes/test_rq_api_dss_export.py::test_post_dss_export_rq_mode2_builds_channels` stored an unpadded DSS end date (`03/01/3`), causing the unit test to fail.

## Root Cause
`format_dss_date` delegated to `strftime`, and this libc build omits leading zeros for `%Y` when the year is < 1000, so early simulation years were serialized incorrectly.

## Solution
Format DSS dates manually via f-strings to guarantee the `MM/DD/YYYY` contract regardless of platform quirks.

## Testing
ssh nuc2.local "cd /workdir/wepppy && wctl run-pytest -q tests/weppcloud/routes/test_rq_api_dss_export.py::test_post_dss_export_rq_mode2_builds_channels"

## Edge Cases
None; empty inputs still yield `None`, and normal calendar years retain the same formatting.

**Agent Confidence:** High