### PR TITLE
Fix: run sync dashboard job enqueue

### DIFF
--- a/wepppy/weppcloud/routes/run_sync_dashboard/run_sync_dashboard.py
+++ b/wepppy/weppcloud/routes/run_sync_dashboard/run_sync_dashboard.py
@@ -173,7 +173,7 @@ def api_run_sync():
                 timeout=RUN_SYNC_TIMEOUT,
             )
             
-            jobs_info = {'sync_job_id': sync_job.id}
+            jobs_info = {'job_id': sync_job.id, 'sync_job_id': sync_job.id}
             
             # Optionally chain migrations job
             if run_migrations:
@@ -185,7 +185,7 @@ def api_run_sync():
                 migration_job = queue.enqueue_call(
                     migrations_rq,
                     (wd, runid),
-                    {'archive_before': archive_before},
+                    kwargs={'archive_before': archive_before},
                     timeout=MIGRATIONS_TIMEOUT,
                     depends_on=sync_job,
                 )


### PR DESCRIPTION
## Problem
POST /rq/api/run-sync returned 500 in tests when migrations chaining was enabled, so the doc-janitor dashboard flow could not enqueue work via the API and the regression test failed.

## Root Cause
The migrations job was enqueued using a positional kwargs argument which the Queue stub treated as the timeout slot, raising a multiple-values error and preventing the handler from reaching the response body that older clients still expect.

## Solution
Call enqueue_call with an explicit kwargs= argument and return both job_id and sync_job_id so legacy clients keep working while the new migrations id stays available.

## Testing
PYTHONPATH=/workdir/wepppy/.venv-wctl/lib/python3.12/site-packages wctl run-pytest -q tests/weppcloud/routes/test_run_sync_dashboard.py::test_api_run_sync_enqueues_job

## Edge Cases
Requests with run_migrations disabled still get a 200 + job id, and the optional migration enqueue keeps the depends_on chain while respecting archive_before.

**Agent Confidence:** high
