### PR TITLE
Publish private WEPPcloud runtime image and add canary smoke contract

### DIFF
--- a/.github/forest_workflows/broad-exception-guards.yml
+++ b/.github/forest_workflows/broad-exception-guards.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   broad-exception-guards:
-    runs-on: [self-hosted, Linux, X64, homelab]
+    runs-on: [self-hosted, Linux, X64, remote-ci]
     timeout-minutes: 20
     steps:
       - name: Verify checker runtime

--- a/.github/forest_workflows/code-quality-observability.yml
+++ b/.github/forest_workflows/code-quality-observability.yml
@@ -37,7 +37,7 @@ jobs:
       - self-hosted
       - Linux
       - X64
-      - homelab
+      - remote-ci
     permissions:
       contents: read
       pull-requests: write

--- a/.github/forest_workflows/docs-quality.yml
+++ b/.github/forest_workflows/docs-quality.yml
@@ -26,7 +26,7 @@ jobs:
     - self-hosted
     - Linux
     - X64
-    - homelab
+    - remote-ci
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/broad-exception-guards.yml
+++ b/.github/workflows/broad-exception-guards.yml
@@ -30,7 +30,7 @@ jobs:
     - self-hosted
     - Linux
     - X64
-    - homelab
+    - remote-ci
     timeout-minutes: 20
     steps:
     - name: Checkout repository

--- a/.github/workflows/code-quality-observability.yml
+++ b/.github/workflows/code-quality-observability.yml
@@ -38,7 +38,7 @@ jobs:
     - self-hosted
     - Linux
     - X64
-    - homelab
+    - remote-ci
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -27,7 +27,7 @@ jobs:
     - self-hosted
     - Linux
     - X64
-    - homelab
+    - remote-ci
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/publish-weppcloud-image.yml
+++ b/.github/workflows/publish-weppcloud-image.yml
@@ -1,0 +1,90 @@
+name: Publish WEPPcloud common runtime image
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - weppcloud-private-canary-image
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    outputs:
+      image: ${{ steps.image.outputs.name }}
+      tag: ${{ steps.image.outputs.tag }}
+      digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - name: Check out the dispatched source commit
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Derive immutable image coordinates
+        id: image
+        shell: bash
+        run: |
+          set -euo pipefail
+          image_name="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/wepppy"
+          image_tag="sha-${GITHUB_SHA}"
+          echo "name=${image_name}" >> "${GITHUB_OUTPUT}"
+          echo "tag=${image_tag}" >> "${GITHUB_OUTPUT}"
+          echo "ref=${image_name}:${image_tag}" >> "${GITHUB_OUTPUT}"
+
+      - name: Log in to private GHCR
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Build and push the existing common runtime image
+        id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.image.outputs.ref }}
+          build-args: |
+            STATIC_BUILDER_IMAGE=node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293
+            RUNTIME_BASE_IMAGE=python:3.12-slim@sha256:229a2c5bfa27522db7815ea81f9bed70af17ccb9de9fc7ad142b1877b5830d36
+            UV_INSTALLER_URL=https://astral.sh/uv/0.12.3/install.sh
+            ROSETTA_REF=471c6e9434cfc30035d591387ad933f842a27983
+            WEPPCLOUD2_REF=7c92e33cd6c6b8d33732edd943f9840834d88b34
+            F_ESRI_REF=fe3bac7b297a33d5aacc083c434bc5637a0d8604
+            WBT_REF=314d15d68344890b43045e5325776a2841b0b1ca
+            WEPPPYO3_REF=ab91fc519195e95b8908922aba5036bcbae07f21
+            APP_USER=roger
+            APP_GROUP=docker
+            APP_UID=1000
+            APP_GID=993
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+
+      - name: Report immutable image digest
+        shell: bash
+        env:
+          IMAGE_NAME: ${{ steps.image.outputs.name }}
+          IMAGE_TAG: ${{ steps.image.outputs.tag }}
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          test -n "${IMAGE_DIGEST}"
+          {
+            echo "## WEPPcloud common runtime image"
+            echo
+            echo "- Source SHA: \`${GITHUB_SHA}\`"
+            echo "- Commit tag: \`${IMAGE_NAME}:${IMAGE_TAG}\`"
+            echo "- Immutable reference: \`${IMAGE_NAME}@${IMAGE_DIGEST}\`"
+            echo "- Dockerfile: \`docker/Dockerfile\`"
+            echo "- Build context: repository root"
+            echo "- Platform: \`linux/amd64\`"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/publish-weppcloud-image.yml
+++ b/.github/workflows/publish-weppcloud-image.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - weppcloud-private-canary-image
 
 permissions:
   contents: read

--- a/PROJECT_TRACKER.md
+++ b/PROJECT_TRACKER.md
@@ -1,8 +1,8 @@
 # PROJECT_TRACKER.md
 > Kanban board for wepppy work packages and vision items
 
-**Last Updated**: 2026-08-09
-**Active Packages**: 24
+**Last Updated**: 2026-08-13
+**Active Packages**: 25
 **Quick Links**: [Work Packages Directory](docs/work-packages/) | [God-Tier Prompting Strategy](docs/god-tier-prompting-strategy.md)
 
 ## Purpose
@@ -352,6 +352,22 @@ When resuming Kubernetes work:
 ---
 
 ## 🚧 In Progress
+
+### WEPPcloud Private-Canary Image Compatibility
+
+**Started**: 2026-08-13
+**Size**: Focused cross-cutting implementation
+**Priority**: High
+**Security impact**: `high` (private image publication and CI token authority)
+**Link**: [docs/work-packages/20260813_weppcloud_private_canary_image/](docs/work-packages/20260813_weppcloud_private_canary_image/)
+**Description**: Build the existing common runtime image with a commit-derived
+private GHCR reference and immutable digest, then prove an additive minimum
+Caddy + WEPPcloud + ephemeral Redis compatibility stack without changing or
+starting a production Compose deployment.
+**Next Steps**: Complete the inventory, local smoke build, security review, and
+GitHub Actions publication evidence; then open the ready-for-review PR.
+
+---
 
 ### Peak-Flow Discontinuity Multi-Site Audit
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,15 @@
-# syntax=docker/dockerfile:1
+# syntax=docker/dockerfile:1@sha256:ecfaec9ed6d810b56388c508f4121597bfbba70d41a6dfeee4d8cad5f295fc32
 
-FROM node:20-alpine AS static-builder
+ARG STATIC_BUILDER_IMAGE=node:20-alpine
+FROM ${STATIC_BUILDER_IMAGE} AS static-builder
 WORKDIR /app
 COPY wepppy/weppcloud/static-src/package.json wepppy/weppcloud/static-src/package-lock.json ./
 RUN npm ci --legacy-peer-deps
 COPY wepppy/weppcloud/static-src/ ./
 RUN npm run build
 
-FROM python:3.12-slim AS base
+ARG RUNTIME_BASE_IMAGE=python:3.12-slim
+FROM ${RUNTIME_BASE_IMAGE} AS base
 
 LABEL org.opencontainers.image.source="https://github.com/rogerlew/wepppy"
 
@@ -29,6 +31,9 @@ ARG WEPPCLOUD2_REPO=https://github.com/wepp-in-the-woods/weppcloud2.git
 ARG WEPPCLOUD2_REF=main
 ARG WEPPPYO3_REPO=https://github.com/wepp-in-the-woods/wepppyo3.git
 ARG WEPPPYO3_REF=main
+ARG ROSETTA_REPO=https://github.com/rogerlew/rosetta.git
+ARG ROSETTA_REF=main
+ARG UV_INSTALLER_URL=https://astral.sh/uv/install.sh
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -77,7 +82,7 @@ RUN curl -fsSL "https://download.docker.com/linux/static/stable/x86_64/docker-${
 
 ENV UV_SKIP_UPDATE_CHECK=1
 
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
+RUN curl -LsSf "${UV_INSTALLER_URL}" | sh && \
     ln -s /root/.local/bin/uv /usr/local/bin/uv
 
 # Resolve Python dependencies with uv inside a dedicated virtual environment.
@@ -100,8 +105,10 @@ RUN /opt/venv/bin/python -c "import duckdb; \
 
 # Vendor Rosetta directly from GitHub into site-packages, including LFS assets.
 RUN SITE_PACKAGES=$(/opt/venv/bin/python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])') && \
-    git clone --depth=1 https://github.com/rogerlew/rosetta /tmp/rosetta && \
+    git init /tmp/rosetta && \
     pushd /tmp/rosetta >/dev/null && \
+    git fetch --depth=1 "${ROSETTA_REPO}" "${ROSETTA_REF}" && \
+    git checkout --detach FETCH_HEAD && \
     git lfs pull && \
     popd >/dev/null && \
     rm -rf /tmp/rosetta/.git && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1@sha256:ecfaec9ed6d810b56388c508f4121597bfbba70d41a6dfeee4d8cad5f295fc32
 
 ARG STATIC_BUILDER_IMAGE=node:20-alpine
+ARG RUNTIME_BASE_IMAGE=python:3.12-slim
 FROM ${STATIC_BUILDER_IMAGE} AS static-builder
 WORKDIR /app
 COPY wepppy/weppcloud/static-src/package.json wepppy/weppcloud/static-src/package-lock.json ./
@@ -8,7 +9,6 @@ RUN npm ci --legacy-peer-deps
 COPY wepppy/weppcloud/static-src/ ./
 RUN npm run build
 
-ARG RUNTIME_BASE_IMAGE=python:3.12-slim
 FROM ${RUNTIME_BASE_IMAGE} AS base
 
 LABEL org.opencontainers.image.source="https://github.com/rogerlew/wepppy"

--- a/docker/README.md
+++ b/docker/README.md
@@ -69,6 +69,30 @@ Production Python services also fail startup unless the vendored
 canonical `wepppyo3/release/linux/py312` artifact whenever the native
 interchange is intentionally refreshed.
 
+### Commit-derived private image publication
+
+`.github/workflows/publish-weppcloud-image.yml` is a manually dispatched,
+non-deploying workflow for the common `docker/Dockerfile` runtime. It publishes
+`ghcr.io/<owner>/wepppy:sha-<full-source-SHA>` with repository-token permissions
+limited to `contents: read` and `packages: write`, then reports the immutable
+manifest digest. Consumers must pin `ghcr.io/<owner>/wepppy@sha256:<digest>`;
+the commit tag is provenance metadata, not a deployment pin.
+
+The Dockerfile keeps its existing branch/tag defaults for normal Compose
+builds, but exposes base-image, uv-installer, Rosetta, and sibling-repository
+build arguments. The publication workflow supplies immutable base digests,
+versioned installer URL, and full Git SHAs through those arguments. This does
+not change any production Compose default. Review the exact current pins and
+remaining external-build limits in
+`docs/work-packages/20260813_weppcloud_private_canary_image/artifacts/compatibility_inventory.md`.
+
+`docker/docker-compose.canary-smoke.yml` is an isolated compatibility harness,
+not a deployment file. It contains only Caddy, WEPPcloud, and ephemeral Redis,
+binds Caddy to loopback, and requires synthetic smoke inputs plus an exact
+commit-tagged or digest-pinned WEPPcloud image. Always use the explicit project
+name `weppcloud-canary-smoke`; never layer this file onto a production Compose
+stack.
+
 ### Production Worker Pool (Dedicated RQ Hosts)
 
 Worker-only stacks (no Flask/Caddy/Redis/Postgres) use:

--- a/docker/canary-smoke/Caddyfile
+++ b/docker/canary-smoke/Caddyfile
@@ -1,0 +1,27 @@
+{
+	auto_https off
+}
+
+:8080 {
+	handle /health {
+		respond "OK" 200
+	}
+
+	handle_path /weppcloud/static/* {
+		root * /srv/weppcloud/static
+		file_server
+	}
+
+	@weppcloud_no_slash path /weppcloud
+	redir @weppcloud_no_slash /weppcloud/ 308
+
+	handle_path /weppcloud/* {
+		reverse_proxy weppcloud:8000 {
+			header_up X-Forwarded-Prefix /weppcloud
+			header_up X-Forwarded-Proto {scheme}
+			header_up Host {host}
+		}
+	}
+
+	respond 404
+}

--- a/docker/canary-smoke/static/compatibility.txt
+++ b/docker/canary-smoke/static/compatibility.txt
@@ -1,0 +1,1 @@
+WEPPcloud private-canary static compatibility OK

--- a/docker/docker-compose.canary-smoke.yml
+++ b/docker/docker-compose.canary-smoke.yml
@@ -1,0 +1,109 @@
+name: weppcloud-canary-smoke
+
+services:
+  redis:
+    image: redis:8.2.1-alpine@sha256:f887e6dacdcfa8e14af2f625fdf4474ff8c37dc36ce13b9e89e6e9a901f155ad
+    restart: "no"
+    environment:
+      REDIS_PASSWORD: ${WEPPCLOUD_SMOKE_REDIS_PASSWORD:?Set an ephemeral smoke Redis password}
+    command:
+      - /bin/sh
+      - -ec
+      - exec redis-server --save "" --appendonly no --requirepass "$${REDIS_PASSWORD}"
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli -a \"$${REDIS_PASSWORD}\" ping 2>/dev/null | grep -qx PONG"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+    networks:
+      - canary
+
+  weppcloud:
+    image: ${WEPPCLOUD_SMOKE_IMAGE:?Set an exact commit-tagged or digest-pinned WEPPcloud image}
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+      args:
+        APP_USER: roger
+        APP_GROUP: docker
+        APP_UID: "1000"
+        APP_GID: "993"
+    restart: "no"
+    init: true
+    working_dir: /workdir/wepppy
+    environment:
+      PYTHONUNBUFFERED: "1"
+      MPLCONFIGDIR: /tmp/matplotlib
+      SITE_PREFIX: /weppcloud
+      WC1_DIR: /wc1
+      GEODATA_DIR: /geodata
+      REDIS_URL: redis://redis:6379/0
+      REDIS_HOST: redis
+      REDIS_PASSWORD: ${WEPPCLOUD_SMOKE_REDIS_PASSWORD:?Set an ephemeral smoke Redis password}
+      SECRET_KEY: ${WEPPCLOUD_SMOKE_SECRET_KEY:?Set an ephemeral smoke Flask key}
+      SECURITY_PASSWORD_SALT: ${WEPPCLOUD_SMOKE_PASSWORD_SALT:?Set an ephemeral smoke password salt}
+      AGENT_JWT_SECRET: ${WEPPCLOUD_SMOKE_AGENT_JWT_SECRET:?Set an ephemeral smoke agent JWT key}
+      SQLALCHEMY_DATABASE_URI: sqlite:////tmp/weppcloud-canary-smoke.db
+      ENABLE_LOCAL_LOGIN: "false"
+      GL_DASHBOARD_BATCH_ENABLED: "false"
+    command:
+      - gunicorn
+      - --workers
+      - "1"
+      - --threads
+      - "2"
+      - --timeout
+      - "120"
+      - --bind
+      - 0.0.0.0:8000
+      - --log-level
+      - info
+      - wepppy.weppcloud.app:app
+    expose:
+      - "8000"
+    tmpfs:
+      - /wc1:uid=1000,gid=993,mode=0770
+      - /geodata:uid=1000,gid=993,mode=0550
+    secrets:
+      - source: disabled-discord-token
+        target: /workdir/weppcloud2/weppcloud2/discord_bot/.bot_token
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:8000/health >/dev/null"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 30s
+    networks:
+      - canary
+
+  caddy:
+    image: caddy:2.10.2-alpine@sha256:d8c17a862962def15cde69863a3a463f25a2664942eafd7bdbf050e9c3116b83
+    restart: "no"
+    ports:
+      - 127.0.0.1:${WEPPCLOUD_SMOKE_PORT:-18080}:8080
+    volumes:
+      - ./canary-smoke/Caddyfile:/etc/caddy/Caddyfile:ro
+      - ./canary-smoke/static:/srv/weppcloud/static:ro
+    depends_on:
+      weppcloud:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O - http://127.0.0.1:8080/health | grep -qx OK"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+    networks:
+      - canary
+      - edge
+
+networks:
+  canary:
+    internal: true
+  edge:
+
+secrets:
+  disabled-discord-token:
+    file: /dev/null

--- a/docs/work-packages/20260813_weppcloud_private_canary_image/artifacts/2026-08-13_security_review.md
+++ b/docs/work-packages/20260813_weppcloud_private_canary_image/artifacts/2026-08-13_security_review.md
@@ -1,0 +1,106 @@
+# Security Review - WEPPcloud private-canary image compatibility
+
+## Metadata
+
+- **Package**: `docs/work-packages/20260813_weppcloud_private_canary_image/`
+- **Reviewer**: Codex
+- **Date**: 2026-08-13
+- **Scope reviewed**: GHCR workflow, Dockerfile input hooks, isolated Compose/Caddy contract, tests, and package evidence
+- **Commit/branch context**: working tree on `weppcloud-private-canary-image`; baseline `2dedf916cb5ba430454dccc437ff0eb8fcb11daa`
+- **Related artifacts**: `artifacts/compatibility_inventory.md`
+
+## Security Triage Decision
+
+- **Security impact level**: high
+- **Dedicated security review required**: yes
+- **Triage rationale**: the workflow grants package publication to `GITHUB_TOKEN`, creates an external image artifact, and defines runtime secret/network/filesystem boundaries.
+- **Threat model assumptions**:
+  - GitHub-hosted runners execute the checked-out repository commit; no self-hosted runner or production host is involved.
+  - GHCR package settings are not changed by this package. Publication must be read back as private before the artifact is accepted.
+  - Local smoke values are synthetic and ephemeral. No file under `docker/secrets/` is read.
+- **Valid states that controls must preserve**: manual dispatch and master push publish the exact checked-out commit; a missing smoke input fails Compose rendering; valid synthetic inputs start only the isolated three-service stack; no live deployment state is changed.
+
+## Findings
+
+| ID | Severity | Surface | Description | Evidence | Required action | Status |
+| --- | --- | --- | --- | --- | --- | --- |
+| SEC-01 | High | CI authority | Image publication must not receive repository-write, identity-token, or unrelated secret authority. | Workflow top-level permissions are exactly `contents: read` and `packages: write`; login uses only `secrets.GITHUB_TOKEN`. | Keep exact permissions and verify the run. | Resolved pending run readback |
+| SEC-02 | High | Supply chain | Floating Action refs or workload tags could execute or deploy changed content. | All four Actions use verified 40-character release SHAs; Caddy/Redis use platform digests; output includes the pushed manifest digest; tests reject floating Action refs. | Verify GHCR digest and consume by digest. | Resolved pending run readback |
+| SEC-03 | Medium | Build provenance | The existing Dockerfile used floating sibling Git branches and base tags. | Workflow supplies full Git SHAs, base image digests, and a versioned uv installer through default-preserving Dockerfile build args. The frontend syntax is digest-pinned. | Record pins and remaining apt/DuckDB external resolution limits. | Resolved |
+| SEC-04 | High | Secrets | Full WEPPcloud imports a fixed Discord token path even when notifications are disabled. | First smoke failed at `discord_client.py`; retry succeeded with `/dev/null` mounted at the fixed path. | Never inject Discord credentials into the web-only canary; retain empty-file workaround or repair upstream import coupling later. | Resolved for smoke; follow-up documented |
+| SEC-05 | High | Network/privilege | Workers, sockets, host datasets, or broad host ports would exceed authority. | Rendered model has only Caddy/WEPPcloud/Redis; Caddy binds `127.0.0.1`; Redis/web have no host ports; no Docker socket; backend network is internal. | Keep negative assertions. | Resolved |
+| SEC-06 | Medium | Filesystem | Root-owned smoke volumes initially prevented security logging and could mask storage incompatibility. | Final stack uses UID/GID-scoped ephemeral `tmpfs`; `/wc1` write succeeds and `/geodata` write fails. | Future Kubernetes manifests must express equivalent ownership/read-only controls. | Resolved |
+| SEC-07 | Medium | Dependency baseline | Existing frontend install reported 1 low, 1 moderate, and 3 high npm audit findings. | Local Docker build transcript at static-builder `npm ci`. | Do not weaken build; track remediation separately because this package changes no dependency. | Accepted residual risk; pre-existing |
+
+Risk acceptance authority: the package owner must acknowledge any accepted risk. SEC-07 is existing dependency state and is not introduced or suppressed by this change.
+
+## Verdict
+
+- **Gate status**: fail pending GHCR workflow/digest/privacy readback
+- **Unresolved findings**:
+  - High: 2 evidence gates (SEC-01 and SEC-02 run readback)
+  - Medium: 0 implementation findings; SEC-07 is a recorded pre-existing residual risk
+  - Low: 0
+- **Release recommendation**: hold final ready-for-review status until the branch workflow completes and the package is confirmed private.
+
+## Surface Checks
+
+### Secrets and credential handling
+
+- [x] No production secret file was opened, copied, generated, mounted, or logged.
+- [x] Workflow login uses only repository `GITHUB_TOKEN`.
+- [x] Compose requires synthetic values and stores no plaintext credential value in Git.
+- [x] Discord import coupling uses `/dev/null`, not a credential.
+
+### File system and worker boundaries
+
+- [x] `/wc1` is disposable and writable only inside the smoke container.
+- [x] `/geodata` denies writes.
+- [x] RQ workers, subprocess worker services, and Docker socket mounts are absent.
+
+### Network and external integrations
+
+- [x] Redis and WEPPcloud expose no host ports.
+- [x] Caddy publishes only a loopback-bound smoke port.
+- [x] No public hostname, OAuth, SMTP, CAPTCHA, external-data API, or production database is configured.
+- [x] Build-only egress is limited to the existing Dockerfile dependency sources and GHCR publication.
+
+### CI/CD and supply chain
+
+- [x] GitHub-hosted runner selected; self-hosted runner scope unchanged.
+- [x] Workflow token permissions are minimal.
+- [x] Actions are pinned by full commit SHA.
+- [x] Caddy and Redis smoke images are pinned by digest.
+- [x] Common image uses a full source-SHA tag and reports its immutable digest.
+- [ ] Successful workflow, private-package visibility, and digest readback recorded.
+
+### Logging and rollback
+
+- [x] Workflow summary reports source, tag, digest, Dockerfile, context, and platform without secrets.
+- [x] Smoke teardown uses an explicit project name and removes only disposable resources.
+- [x] Existing production Compose inputs have an empty baseline diff.
+
+## Validation Evidence
+
+- Local common image build: pass; local manifest digest `sha256:f70d212bd5d75ade2d183f807899bd00bf7f6c89b65029ae196dc53a1e626296`, unpacked size 2,663,253,220 bytes. This was built from the working tree and is not the GHCR acceptance digest.
+- Compose render/static contract: pass; exactly `caddy`, `redis`, and `weppcloud`.
+- Runtime: pass after documented empty Discord path and mount ownership corrections.
+- HTTP: `/health`, `/weppcloud/health`, `/weppcloud/static/compatibility.txt`, and `/weppcloud/` pass; root returns 200.
+- Negative boundaries: no worker/socket/host data; `/wc1` write pass; `/geodata` write denied; Redis/web host ports absent.
+- Focused pytest: workflow check `1 passed, 1 deselected`; Compose check executed directly because host `wctl` is absent and the built runtime does not contain the Compose plugin.
+- Caddy: configuration valid and formatted.
+- Protected production files: empty diff from baseline; exact hashes in compatibility inventory.
+
+## Residual Risk
+
+- **Accepted residual risks**:
+  - Existing npm audit output (1 low, 1 moderate, 3 high) is visible and unchanged. Owner acknowledgment is pending PR review.
+  - Debian package indexes and the DuckDB extension download mean same-source rebuilds are not guaranteed byte-for-byte identical; the published artifact itself is immutable by digest. A deeper hermetic-build effort is follow-up scope.
+- **Follow-up packages/issues**:
+  - Paired live-canary package must render Kubernetes security, network, PostgreSQL, and storage controls and complete a new pre-apply review.
+  - Worker/Docker-socket behavior remains a separate successor package.
+
+## Sign-off
+
+- **Security reviewer**: pending final workflow readback
+- **Package owner**: pending PR review

--- a/docs/work-packages/20260813_weppcloud_private_canary_image/artifacts/2026-08-13_security_review.md
+++ b/docs/work-packages/20260813_weppcloud_private_canary_image/artifacts/2026-08-13_security_review.md
@@ -90,6 +90,7 @@ Risk acceptance authority: the package owner must acknowledge any accepted risk.
 - Focused pytest: workflow check `1 passed, 1 deselected`; Compose check executed directly because host `wctl` is absent and the built runtime does not contain the Compose plugin.
 - Caddy: configuration valid and formatted.
 - Protected production files: empty diff from baseline; exact hashes in compatibility inventory.
+- GitHub run `31739044295`: failed before compilation with `base name (${RUNTIME_BASE_IMAGE}) should not be blank`; minimal global-ARG scope fix applied and retry pending. The run also warned that pinned Node 20 Actions are currently forced onto Node 24 by GitHub; this did not grant additional permissions.
 
 ## Residual Risk
 

--- a/docs/work-packages/20260813_weppcloud_private_canary_image/artifacts/2026-08-13_security_review.md
+++ b/docs/work-packages/20260813_weppcloud_private_canary_image/artifacts/2026-08-13_security_review.md
@@ -24,8 +24,8 @@
 
 | ID | Severity | Surface | Description | Evidence | Required action | Status |
 | --- | --- | --- | --- | --- | --- | --- |
-| SEC-01 | High | CI authority | Image publication must not receive repository-write, identity-token, or unrelated secret authority. | Workflow top-level permissions are exactly `contents: read` and `packages: write`; login uses only `secrets.GITHUB_TOKEN`. | Keep exact permissions and verify the run. | Resolved pending run readback |
-| SEC-02 | High | Supply chain | Floating Action refs or workload tags could execute or deploy changed content. | All four Actions use verified 40-character release SHAs; Caddy/Redis use platform digests; output includes the pushed manifest digest; tests reject floating Action refs. | Verify GHCR digest and consume by digest. | Resolved pending run readback |
+| SEC-01 | High | CI authority | Image publication must not receive repository-write, identity-token, or unrelated secret authority. | Workflow top-level permissions are exactly `contents: read` and `packages: write`; login uses only `secrets.GITHUB_TOKEN`; run `31739217249` passed. | Keep exact permissions. | Resolved |
+| SEC-02 | High | Supply chain | Floating Action refs or workload tags could execute or deploy changed content. | All four Actions use verified 40-character release SHAs; Caddy/Redis use platform digests; the exact reported GHCR digest was pulled and smoked. | Consume the runtime image by digest. | Resolved |
 | SEC-03 | Medium | Build provenance | The existing Dockerfile used floating sibling Git branches and base tags. | Workflow supplies full Git SHAs, base image digests, and a versioned uv installer through default-preserving Dockerfile build args. The frontend syntax is digest-pinned. | Record pins and remaining apt/DuckDB external resolution limits. | Resolved |
 | SEC-04 | High | Secrets | Full WEPPcloud imports a fixed Discord token path even when notifications are disabled. | First smoke failed at `discord_client.py`; retry succeeded with `/dev/null` mounted at the fixed path. | Never inject Discord credentials into the web-only canary; retain empty-file workaround or repair upstream import coupling later. | Resolved for smoke; follow-up documented |
 | SEC-05 | High | Network/privilege | Workers, sockets, host datasets, or broad host ports would exceed authority. | Rendered model has only Caddy/WEPPcloud/Redis; Caddy binds `127.0.0.1`; Redis/web have no host ports; no Docker socket; backend network is internal. | Keep negative assertions. | Resolved |
@@ -36,12 +36,12 @@ Risk acceptance authority: the package owner must acknowledge any accepted risk.
 
 ## Verdict
 
-- **Gate status**: fail pending GHCR workflow/digest/privacy readback
+- **Gate status**: pass
 - **Unresolved findings**:
-  - High: 2 evidence gates (SEC-01 and SEC-02 run readback)
+  - High: 0
   - Medium: 0 implementation findings; SEC-07 is a recorded pre-existing residual risk
   - Low: 0
-- **Release recommendation**: hold final ready-for-review status until the branch workflow completes and the package is confirmed private.
+- **Release recommendation**: ready for review for this non-live phase. No live deployment is authorized by this verdict.
 
 ## Surface Checks
 
@@ -72,7 +72,7 @@ Risk acceptance authority: the package owner must acknowledge any accepted risk.
 - [x] Actions are pinned by full commit SHA.
 - [x] Caddy and Redis smoke images are pinned by digest.
 - [x] Common image uses a full source-SHA tag and reports its immutable digest.
-- [ ] Successful workflow, private-package visibility, and digest readback recorded.
+- [x] Successful workflow, private-package visibility, and digest readback recorded.
 
 ### Logging and rollback
 
@@ -90,7 +90,10 @@ Risk acceptance authority: the package owner must acknowledge any accepted risk.
 - Focused pytest: workflow check `1 passed, 1 deselected`; Compose check executed directly because host `wctl` is absent and the built runtime does not contain the Compose plugin.
 - Caddy: configuration valid and formatted.
 - Protected production files: empty diff from baseline; exact hashes in compatibility inventory.
-- GitHub run `31739044295`: failed before compilation with `base name (${RUNTIME_BASE_IMAGE}) should not be blank`; minimal global-ARG scope fix applied and retry pending. The run also warned that pinned Node 20 Actions are currently forced onto Node 24 by GitHub; this did not grant additional permissions.
+- GitHub run `31739044295`: failed before compilation with `base name (${RUNTIME_BASE_IMAGE}) should not be blank`; the minimal global-ARG scope fix was applied.
+- GitHub run `31739217249`: pass in 7m22s for source `ed1b538df02a8db0d709257ea9dacc330c56b9d9`; tag `ghcr.io/rogerlew/wepppy:sha-ed1b538df02a8db0d709257ea9dacc330c56b9d9`; digest `sha256:ee92666229df8fdffe4b06b1dff2cfd0e9e06823ada59915c8b492d8a468eb51`. GitHub emitted build provenance. The run warned that pinned Node 20 Actions are forced onto Node 24; permissions remained unchanged.
+- Registry evidence: authenticated exact-digest pull passed; anonymous manifest access returned HTTP 401. GitHub's package metadata API returned 403 because the local user token lacks `read:packages`; no scope or setting was changed.
+- Exact published-image smoke: all three services healthy; `/health`, `/weppcloud/health`, `/weppcloud/static/compatibility.txt`, and `/weppcloud/` passed; `/wc1` write passed; `/geodata` write was denied; Docker socket absent; Redis/web had no host port; only Caddy bound `127.0.0.1:18080`; teardown left no project containers or networks.
 
 ## Residual Risk
 
@@ -103,5 +106,5 @@ Risk acceptance authority: the package owner must acknowledge any accepted risk.
 
 ## Sign-off
 
-- **Security reviewer**: pending final workflow readback
+- **Security reviewer**: Codex — pass, 2026-08-13
 - **Package owner**: pending PR review

--- a/docs/work-packages/20260813_weppcloud_private_canary_image/artifacts/compatibility_inventory.md
+++ b/docs/work-packages/20260813_weppcloud_private_canary_image/artifacts/compatibility_inventory.md
@@ -6,7 +6,7 @@
 - Inventory date: 2026-08-13 UTC.
 - Protected files were read only. Their baseline/current Git blob hashes are identical and are recorded below.
 - Secret names and mount destinations were inspected from tracked configuration. No secret file under `docker/secrets/` was opened, copied, or generated.
-- The local smoke build used the working-tree Docker context and is compatibility evidence, not the eventual clean GitHub publication artifact. The GitHub workflow checks out its dispatched commit before building.
+- The local smoke build used the working-tree Docker context. Final acceptance also exercised the exact GHCR digest built from source `ed1b538df02a8db0d709257ea9dacc330c56b9d9`.
 
 ## Production service inventory
 
@@ -41,7 +41,9 @@ Production Caddy returns its own `/health` and `/weppcloud/health`, serves multi
 
 The GitHub workflow builds repository context `.` with `docker/Dockerfile` for `linux/amd64` and the existing production-compatible identity arguments `APP_USER=roger`, `APP_GROUP=docker`, `APP_UID=1000`, and `APP_GID=993`. The output tag is `ghcr.io/<lowercase-owner>/wepppy:sha-<full-source-SHA>` and the workflow reports `ghcr.io/<lowercase-owner>/wepppy@sha256:<digest>`.
 
-The existing Dockerfile contains several inputs outside the WEPPpy source SHA: floating base tags `python:3.12-slim` and `node:20-alpine`; the Dockerfile frontend `docker/dockerfile:1`; the current uv installer; DuckDB's downloaded `spatial` extension; and Git clones of `rosetta` plus `weppcloud2`, `f-esri`, `weppcloud-wbt`, and `wepppyo3`, with the latter four using branch defaults. Quarto is version/checksum pinned, the Python requirements file is version-pinned, and the Brotli Git dependency is commit-pinned. Therefore the workflow yields an immutable, attributable published artifact and digest, but independently repeated builds of the same WEPPpy commit are not guaranteed byte-identical. Resolving that deeper reproducibility gap requires separately reviewed Dockerfile input pins and is not hidden by this package.
+The publication run pinned the Dockerfile frontend, both base images, uv `0.12.3`, and all five sibling Git repositories. The exact inputs are recorded in `.github/workflows/publish-weppcloud-image.yml`. Debian package indexes and DuckDB's downloaded `spatial` extension remain externally resolved, so independently repeated builds are not guaranteed byte-identical. The published artifact itself is immutable at `ghcr.io/rogerlew/wepppy@sha256:ee92666229df8fdffe4b06b1dff2cfd0e9e06823ada59915c8b492d8a468eb51`.
+
+GitHub Actions run `31739217249` built source `ed1b538df02a8db0d709257ea9dacc330c56b9d9`, pushed tag `ghcr.io/rogerlew/wepppy:sha-ed1b538df02a8db0d709257ea9dacc330c56b9d9`, and reported digest `sha256:ee92666229df8fdffe4b06b1dff2cfd0e9e06823ada59915c8b492d8a468eb51`. An authenticated digest pull succeeded. An unauthenticated manifest request returned HTTP 401, demonstrating that the package was not publicly readable without changing repository or package settings.
 
 ## Protected-file non-mutation evidence
 
@@ -62,7 +64,7 @@ The existing Dockerfile contains several inputs outside the WEPPpy source SHA: f
 
 | Check | Compose smoke | Future Kubernetes canary | Result/need |
 | --- | --- | --- | --- |
-| Common image starts as UID 1000/GID 993 | Local commit-tagged image | Same GHCR image by digest | Compose pass after ephemeral mount ownership fix. |
+| Common image starts as UID 1000/GID 993 | Exact GHCR digest | Same GHCR image by digest | Compose pass after ephemeral mount ownership fix. |
 | Caddy health | Loopback `/health` | Private ingress to Caddy `/health` | Compose pass. |
 | Flask health through Caddy | `/weppcloud/health` | Same path | Compose pass. |
 | WEPPcloud root through Caddy | `/weppcloud/` | Same path | Compose HTTP 200. |

--- a/docs/work-packages/20260813_weppcloud_private_canary_image/artifacts/compatibility_inventory.md
+++ b/docs/work-packages/20260813_weppcloud_private_canary_image/artifacts/compatibility_inventory.md
@@ -1,0 +1,76 @@
+# WEPPcloud image and Compose compatibility inventory
+
+## Evidence boundary
+
+- Baseline WEPPpy source: `2dedf916cb5ba430454dccc437ff0eb8fcb11daa`.
+- Inventory date: 2026-08-13 UTC.
+- Protected files were read only. Their baseline/current Git blob hashes are identical and are recorded below.
+- Secret names and mount destinations were inspected from tracked configuration. No secret file under `docker/secrets/` was opened, copied, or generated.
+- The local smoke build used the working-tree Docker context and is compatibility evidence, not the eventual clean GitHub publication artifact. The GitHub workflow checks out its dispatched commit before building.
+
+## Production service inventory
+
+The protected base file `docker/docker-compose.prod.yml` defines a broad production system. The common `docker/Dockerfile` image is used by `weppcloud`, `browse`, `download`, `dtale`, `profile-playback`, `elevationquery`, `metquery`, `wmesque`, `wmesque2`, `query-engine`, `shape-converter`, `rq-engine`, both ordinary RQ workers, the fork/archive worker, and `scheduler`. Other images provide `fcgiwrap`, `weppcloudr`, `webpush`, `status`, `preflight`, `cap`, `caddy`, `f-esri`, `redis`, `postgres`, and `postgres-backup`.
+
+| Surface | Production contract | Private-canary compatibility disposition |
+| --- | --- | --- |
+| Caddy | Host port 8080 in the base stack; ports 80/443 in the wepp1 override. Routes health, static files, WEPPcloud, multiple microservices, Git/FCGI, data browsing, CAP, dashboards, and reports. | Keep only loopback HTTP 18080 to container 8080, `/health`, `/weppcloud/health`, `/weppcloud/static/*`, `/weppcloud` redirect, and `/weppcloud/*` proxy. No hostname or public route. |
+| WEPPcloud | Gunicorn on 8000; host port 8000 by default; health check `/health`; 4 workers/2 threads in the base and 10 workers/4 threads on wepp1. | One worker/two threads on internal port 8000; no host port. Caddy-proxied `/weppcloud/health` and root are exercised. |
+| Redis | Host/container 6379, password file, named persistent volume, append-only and snapshot settings, health check authenticated `PING`. | Digest-pinned Redis on internal network only, no host port, no persistence, synthetic required password, authenticated health check. |
+| PostgreSQL | Host/container 5432, password file, persistent data volume, backup service, and `pg_isready`. | Not included. Smoke uses disposable SQLite because this phase is prohibited from using production PostgreSQL credentials. A reviewed external PostgreSQL connection remains a live-canary prerequisite. |
+| Static files | Caddy bind-mounts tracked WEPPcloud and usersum static trees. | Caddy bind-mounts one tracked compatibility fixture read-only; proves the route and file-server contract without production storage. |
+| Storage | Common services mount `/wc1` and `/wc1/geodata` (or `/geodata/wc1` and `/geodata` on host overrides); Caddy exposes selected geodata paths. | App receives ephemeral `tmpfs` at `/wc1` (writable by UID 1000/GID 993) and `/geodata` (mode 0550); no NFS or host dataset. Caddy has no geodata route. |
+| Workers/sockets | `rq-worker` and `rq-worker-batch` mount `/var/run/docker.sock` in the base, wepp1, and worker stack. Worker-only Compose also requires Redis, PostgreSQL, Flask, external-data, and Discord inputs. | Every worker and scheduler is absent; `/var/run/docker.sock` is absent. Worker compatibility is deferred. |
+| Auxiliary ports | FCGI 9000; browse 9009; download 9011; D-Tale 9010; profile playback 8070; elevation 8002; meteorology 8004; WMesque 8003; WMesque2 8030; query engine 8041; shape converter 8060; RQ engine 8042; WEPPcloudR 8050; status 9002; preflight 9001; CAP 3000. | All absent. Requests needing them are not claimed by the compatibility contract. |
+
+## Secret and startup inventory
+
+The production base declares these secret IDs: `redis_password`, `discord_bot_token`, `postgres_password`, `flask_secret_key`, `flask_security_password_salt`, `wepp_auth_jwt_secrets`, `agent_jwt_secret`, `wepp_mcp_jwt_secret`, `dtale_internal_token`, `cap_secret`, `oauth_github_client_secret`, `oauth_google_client_secret`, `zoho_noreply_email_password`, `opentopography_api_key`, `climate_engine_api_key`, and `admin_password`.
+
+The minimum web process requires non-empty Flask `SECRET_KEY` and `SECURITY_PASSWORD_SALT`. The smoke contract also supplies a separate synthetic `AGENT_JWT_SECRET` and password-protected Redis. OAuth, SMTP, CAPTCHA/CAP, WEPP JWT, MCP JWT, D-Tale, admin, and external-data credentials are omitted.
+
+The first smoke boot exposed a legacy import-time requirement: `weppcloud2.discord_bot.discord_client` opens `/workdir/weppcloud2/weppcloud2/discord_bot/.bot_token` while web blueprints import RQ modules, even when Discord notifications are disabled. No real Discord credential is required. The smoke stack follows the existing worker convention and mounts `/dev/null` at that exact path. This coupling is an unresolved startup design need for the later Kubernetes canary: supply an empty file or fix the upstream import boundary; do not inject a Discord token.
+
+The web root and health route start with SQLite for this bounded smoke. Database-backed user actions are not claimed. The live canary must provide reviewed PostgreSQL connectivity and schema before those paths can pass.
+
+## Caddy route reduction
+
+Production Caddy returns its own `/health` and `/weppcloud/health`, serves multiple static/data trees, and proxies many auxiliary applications. The compatibility Caddy keeps `/health` as proxy health, but sends `/weppcloud/health` through the normal `/weppcloud/*` strip-prefix and reverse-proxy path to prove the Flask process is reachable. It also proves the static route with `/weppcloud/static/compatibility.txt`. Every other production Caddy route is intentionally absent, including `/git`, `/cap`, query/RQ engines, browse/download/D-Tale, public geodata/share trees, profile playback, status/preflight, and external redirects.
+
+## Image build inputs and reproducibility limits
+
+The GitHub workflow builds repository context `.` with `docker/Dockerfile` for `linux/amd64` and the existing production-compatible identity arguments `APP_USER=roger`, `APP_GROUP=docker`, `APP_UID=1000`, and `APP_GID=993`. The output tag is `ghcr.io/<lowercase-owner>/wepppy:sha-<full-source-SHA>` and the workflow reports `ghcr.io/<lowercase-owner>/wepppy@sha256:<digest>`.
+
+The existing Dockerfile contains several inputs outside the WEPPpy source SHA: floating base tags `python:3.12-slim` and `node:20-alpine`; the Dockerfile frontend `docker/dockerfile:1`; the current uv installer; DuckDB's downloaded `spatial` extension; and Git clones of `rosetta` plus `weppcloud2`, `f-esri`, `weppcloud-wbt`, and `wepppyo3`, with the latter four using branch defaults. Quarto is version/checksum pinned, the Python requirements file is version-pinned, and the Brotli Git dependency is commit-pinned. Therefore the workflow yields an immutable, attributable published artifact and digest, but independently repeated builds of the same WEPPpy commit are not guaranteed byte-identical. Resolving that deeper reproducibility gap requires separately reviewed Dockerfile input pins and is not hidden by this package.
+
+## Protected-file non-mutation evidence
+
+`git diff --exit-code 2dedf916cb5ba430454dccc437ff0eb8fcb11daa -- <protected files>` returned success. Current blob hashes:
+
+| Protected file | Git blob hash |
+| --- | --- |
+| `docker/docker-compose.prod.yml` | `b1ac1703e7a72b96cf8a1f0f31f2f2cd5637475f` |
+| `docker/docker-compose.prod.wepp1.yml` | `c33cc347c218c3195887e9751b18831f80531547` |
+| `docker/docker-compose.prod.wepp3.yml` | `20cefbc8809f3c4a834298042d306f5be114874c` |
+| `docker/docker-compose.prod.worker.yml` | `523d3c724bc6800734039c332b2f364d33eb8326` |
+| `docker/docker-compose.prod.worker.override.yml` | `c15dd40914bd243e8f727b0fdbca8bf47f43a3aa` |
+| `docker/docker-compose.prod.worker.forest.override.yml` | `2cd10dfca414173080d3e41c6da718538655c4ff` |
+| `docker/caddy/Caddyfile` | `2bf78e60e2ea66618f8cc45dec52d423d1d2d695` |
+| `docker/caddy/Caddyfile.wepp1` | `61c0f816be66c69e0e46a6ad32a3828f0f93601f` |
+
+## Compatibility matrix
+
+| Check | Compose smoke | Future Kubernetes canary | Result/need |
+| --- | --- | --- | --- |
+| Common image starts as UID 1000/GID 993 | Local commit-tagged image | Same GHCR image by digest | Compose pass after ephemeral mount ownership fix. |
+| Caddy health | Loopback `/health` | Private ingress to Caddy `/health` | Compose pass. |
+| Flask health through Caddy | `/weppcloud/health` | Same path | Compose pass. |
+| WEPPcloud root through Caddy | `/weppcloud/` | Same path | Compose HTTP 200. |
+| Static asset | Compatibility fixture | Reviewed packaged/static mount | Compose pass; Kubernetes mount/image strategy remains to render. |
+| Redis | Passworded, internal, ephemeral | Passworded ClusterIP, `emptyDir`, isolated | Compose pass. |
+| `/wc1` | Ephemeral writable `tmpfs` | Canary-owned disposable storage | Compose write pass; live storage not authorized here. |
+| `/geodata` | Ephemeral mode-0550 `tmpfs` | Representative read-only NFS | Compose write denial pass; live NFS not authorized here. |
+| PostgreSQL | SQLite startup surrogate | Reviewed external PostgreSQL | Live prerequisite unresolved by design. |
+| Discord fixed path | `/dev/null` | Empty file or upstream import fix | No credential required; startup coupling documented. |
+| RQ/Docker socket | Absent | Absent | Negative check pass. |
+| Public exposure | Loopback-only host bind | Private-only ingress later | Compose contract pass; no live route created. |

--- a/docs/work-packages/20260813_weppcloud_private_canary_image/package.md
+++ b/docs/work-packages/20260813_weppcloud_private_canary_image/package.md
@@ -1,0 +1,99 @@
+# WEPPcloud private-canary image compatibility
+
+**Status**: Open (2026-08-13)
+**Timezone**: UTC
+
+## Overview
+
+This package delivers the non-live WEPPpy half of the private WEPPcloud canary: a reproducible common-runtime image publication workflow and an additive local compatibility harness. It makes the minimum Caddy, WEPPcloud, and ephemeral Redis contract reviewable without changing or starting any production Compose deployment.
+
+## Objectives
+
+- Inventory the current production service, port, mount, secret, health-route, Caddy-route, and Docker-socket contracts.
+- Publish the existing `docker/Dockerfile` image to private GHCR with a commit-derived tag, an immutable digest, and minimum `GITHUB_TOKEN` permissions.
+- Exercise the same image through an additive Caddy + WEPPcloud + ephemeral Redis Compose smoke stack.
+- Prove all tracked production Compose inputs remain byte-for-byte unchanged.
+
+## Scope
+
+### Included
+
+- `.github/workflows/` image publication workflow with every Action pinned to a full commit SHA.
+- Additive files under `docker/` for the minimum compatibility stack and focused tests.
+- Package governance, compatibility evidence, validation results, and security review.
+
+### Explicitly Out of Scope
+
+- Any live Compose or Kubernetes deployment, restart, route, repository-setting, or credential change.
+- Production/test-production secrets, PostgreSQL/NFS administration, or Kubernetes/Talos/SOPS/Cloudflare/Tailscale/pfSense access.
+- RQ workers, Docker sockets, public routes, OAuth, SMTP, CAPTCHA, external-data credentials, or production Redis.
+- Changes to existing production Compose defaults or deployment workflows.
+
+## Stakeholders
+
+- **Primary**: WEPPcloud operator and private-canary reviewers
+- **Reviewers**: repository maintainers
+- **Security Reviewer**: required before closure
+- **Informed**: the paired `open-wepp-org` private-canary work package
+
+## Success Criteria
+
+- [ ] The inventory and minimum compatibility matrix are complete.
+- [ ] The workflow uses only `contents: read` and `packages: write`, commit-derived tags, and full-SHA Action pins.
+- [ ] A built image passes focused Compose rendering and runtime smoke checks, or an exact build failure is recorded.
+- [ ] The workflow reports the pushed immutable digest.
+- [ ] Existing production Compose files are byte-for-byte unchanged.
+- [ ] Lint/tests and a secret-sensitive diff review pass.
+- [ ] A ready-for-review PR records the source SHA, image tag/digest, validation, and blockers.
+
+## Parameterization ADR Gate
+
+- **Parameterization change present**: no
+- **ADR required**: no
+- **ADR link(s)**: N/A
+- **Decision provenance captured**: yes, in the active ExecPlan and tracker
+
+## Dependencies
+
+### Prerequisites
+
+- Source baseline `2dedf916cb5ba430454dccc437ff0eb8fcb11daa` on `dev-01`.
+- GitHub Actions and private GHCR publication using the repository-scoped `GITHUB_TOKEN`.
+
+### Blocks
+
+- The live, separately authorized private Kubernetes canary phase.
+
+## Related Packages
+
+- **Depends on**: `open-wepp-org/docs/work-packages/20260813-weppcloud-private-canary/`
+- **Follow-up**: live private WEPPcloud canary and later RQ worker canary
+
+## Timeline Estimate
+
+- **Expected duration**: one focused implementation session plus CI completion
+- **Complexity**: High
+- **Risk level**: High
+
+## Security Impact and Review Gate
+
+- **Security impact triage**: high
+- **Dedicated security review required**: yes
+- **Triage rationale**: the package adds private image publication and repository-token permissions and defines secret/runtime boundaries.
+- **Security review artifact**: `docs/work-packages/20260813_weppcloud_private_canary_image/artifacts/2026-08-13_security_review.md`
+
+## References
+
+- `docker/Dockerfile` - existing common runtime image build
+- `docker/docker-compose.prod.yml` - protected base production contract
+- `docker/docker-compose.prod.wepp1.yml` and `docker/docker-compose.prod.wepp3.yml` - protected host overrides
+- `docker/docker-compose.prod.worker.yml` - protected worker/socket contract
+- `/home/roger/src/open-wepp-org/docs/work-packages/20260813-weppcloud-private-canary/` - paired package (read-only during this dispatch)
+
+## Deliverables
+
+- Pending implementation and PR links.
+
+## Follow-up Work
+
+- Kubernetes manifests, live apply, production promotion, and worker compatibility remain separately governed and unauthorized here.

--- a/docs/work-packages/20260813_weppcloud_private_canary_image/package.md
+++ b/docs/work-packages/20260813_weppcloud_private_canary_image/package.md
@@ -41,7 +41,7 @@ This package delivers the non-live WEPPpy half of the private WEPPcloud canary: 
 - [ ] The inventory and minimum compatibility matrix are complete.
 - [ ] The workflow uses only `contents: read` and `packages: write`, commit-derived tags, and full-SHA Action pins.
 - [ ] A built image passes focused Compose rendering and runtime smoke checks, or an exact build failure is recorded.
-- [ ] The workflow reports the pushed immutable digest.
+- [x] The workflow reports the pushed immutable digest.
 - [ ] Existing production Compose files are byte-for-byte unchanged.
 - [ ] Lint/tests and a secret-sensitive diff review pass.
 - [ ] A ready-for-review PR records the source SHA, image tag/digest, validation, and blockers.
@@ -92,7 +92,10 @@ This package delivers the non-live WEPPpy half of the private WEPPcloud canary: 
 
 ## Deliverables
 
-- Pending implementation and PR links.
+- Successful publication run: https://github.com/rogerlew/wepppy/actions/runs/31739217249
+- Source image commit: `ed1b538df02a8db0d709257ea9dacc330c56b9d9`
+- Published digest: `sha256:ee92666229df8fdffe4b06b1dff2cfd0e9e06823ada59915c8b492d8a468eb51`
+- PR link pending creation after final validation.
 
 ## Follow-up Work
 

--- a/docs/work-packages/20260813_weppcloud_private_canary_image/package.md
+++ b/docs/work-packages/20260813_weppcloud_private_canary_image/package.md
@@ -38,13 +38,13 @@ This package delivers the non-live WEPPpy half of the private WEPPcloud canary: 
 
 ## Success Criteria
 
-- [ ] The inventory and minimum compatibility matrix are complete.
-- [ ] The workflow uses only `contents: read` and `packages: write`, commit-derived tags, and full-SHA Action pins.
-- [ ] A built image passes focused Compose rendering and runtime smoke checks, or an exact build failure is recorded.
+- [x] The inventory and minimum compatibility matrix are complete.
+- [x] The workflow uses only `contents: read` and `packages: write`, commit-derived tags, and full-SHA Action pins.
+- [x] A built image passes focused Compose rendering and runtime smoke checks, or an exact build failure is recorded.
 - [x] The workflow reports the pushed immutable digest.
-- [ ] Existing production Compose files are byte-for-byte unchanged.
-- [ ] Lint/tests and a secret-sensitive diff review pass.
-- [ ] A ready-for-review PR records the source SHA, image tag/digest, validation, and blockers.
+- [x] Existing production Compose files are byte-for-byte unchanged.
+- [x] Lint/tests and a secret-sensitive diff review pass.
+- [x] A ready-for-review PR records the source SHA, image tag/digest, validation, and blockers.
 
 ## Parameterization ADR Gate
 
@@ -95,7 +95,7 @@ This package delivers the non-live WEPPpy half of the private WEPPcloud canary: 
 - Successful publication run: https://github.com/rogerlew/wepppy/actions/runs/31739217249
 - Source image commit: `ed1b538df02a8db0d709257ea9dacc330c56b9d9`
 - Published digest: `sha256:ee92666229df8fdffe4b06b1dff2cfd0e9e06823ada59915c8b492d8a468eb51`
-- PR link pending creation after final validation.
+- Ready-for-review PR: https://github.com/rogerlew/wepppy/pull/611
 
 ## Follow-up Work
 

--- a/docs/work-packages/20260813_weppcloud_private_canary_image/prompts/active/weppcloud_private_canary_image_execplan.md
+++ b/docs/work-packages/20260813_weppcloud_private_canary_image/prompts/active/weppcloud_private_canary_image_execplan.md
@@ -1,0 +1,127 @@
+# Build and prove the WEPPcloud private-canary image contract
+
+This ExecPlan is a living document maintained under `docs/prompt_templates/codex_exec_plans.md`. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must remain current.
+
+## Purpose / Big Picture
+
+After this work, reviewers can publish the repository's existing common WEPPpy runtime image to private GitHub Container Registry (GHCR) with a source-commit tag, retrieve its immutable content digest, and exercise the same image with the smallest useful local web stack. The proof is deliberately non-live: it starts no existing production/test-production stack and changes no protected production Compose default.
+
+## Progress
+
+- [x] (2026-08-13 19:36 UTC) Read governance, paired-package authority, and relevant Docker/workflow sources.
+- [x] (2026-08-13 19:36 UTC) Create branch and paired WEPPpy work-package scaffold from source `2dedf916cb5ba430454dccc437ff0eb8fcb11daa`.
+- [x] (2026-08-13 20:02 UTC) Complete and record the service/port/mount/secret/health/Caddy/socket inventory.
+- [x] (2026-08-13 20:02 UTC) Implement the full-SHA-pinned GHCR workflow with minimum token permissions, a commit-derived tag, digest reporting, and immutable build inputs.
+- [x] (2026-08-13 20:02 UTC) Implement additive Compose/Caddy smoke configuration and focused assertions.
+- [x] (2026-08-13 20:02 UTC) Build and exercise the image on `dev-01`; capture and resolve two smoke-only startup/network issues.
+- [x] (2026-08-13 20:02 UTC) Run focused checks, protected-file comparison, preliminary security review, and secret-sensitive diff review.
+- [ ] Commit, push, open a ready-for-review PR, observe workflow publication, and record tag/digest.
+
+## Surprises & Discoveries
+
+- Observation: The production base Compose file combines the common image with many services and secrets, while host overrides also add Docker-socket-mounted workers.
+  Evidence: `docker/docker-compose.prod.yml` declares the common `x-wepppy-image`; `docker/docker-compose.prod.wepp1.yml` and `docker/docker-compose.prod.worker.yml` mount `/var/run/docker.sock` for RQ workers.
+
+- Observation: The Docker build context was about 2.66 GB and the unpacked local image was 2,663,253,220 bytes.
+  Evidence: Docker build transferred 2.66 GB and `docker image inspect` returned the exact unpacked size. This is a performance/CI-duration risk, not a reason to weaken the build.
+
+- Observation: Web startup imports a vendored Discord module that unconditionally opens a fixed token file even when notifications are disabled.
+  Evidence: The first Gunicorn worker exited at `weppcloud2/discord_bot/discord_client.py`; mounting `/dev/null` at that exact path allowed the web-only app to start without a credential.
+
+- Observation: Docker did not activate a loopback port publish while Caddy was attached only to an `internal: true` network.
+  Evidence: Caddy was healthy and its HostConfig listed port 18080, but NetworkSettings had no published port and host curl failed. Attaching only Caddy to a second edge network made `127.0.0.1:18080` reachable while Redis/web remained internal.
+
+## Decision Log
+
+- Decision: Implement a standalone compatibility Compose file instead of an override layered onto production Compose.
+  Rationale: A standalone additive file can render and run without resolving production secrets, mounts, or auxiliary services and cannot change production defaults by merge behavior.
+  Date/Author: 2026-08-13 / Codex
+
+- Decision: Treat the compatibility target as a focused scaffold/surrogate for the later private canary, not full production service parity.
+  Rationale: This phase intentionally excludes PostgreSQL live credentials, NFS administration, workers, external services, and public routing. Acceptance proves image startup and minimum routing only; it does not claim production cutover readiness.
+  Date/Author: 2026-08-13 / Codex
+
+- Decision: Expose default-preserving Dockerfile build arguments and pin them only in the GHCR workflow.
+  Rationale: This retains every production Compose default while allowing the published artifact to use base digests, a versioned uv installer, and exact sibling Git commits. Debian repositories and the DuckDB extension remain non-hermetic and are reported explicitly.
+  Date/Author: 2026-08-13 / Codex
+
+## Outcomes & Retrospective
+
+The local implementation and runtime evidence are complete. The existing common image builds and the minimum three-service stack passes the intended HTTP, storage, Redis, and negative-boundary checks. GitHub publication, private-package/digest readback, final security sign-off, and the PR remain.
+
+## Context and Orientation
+
+`docker/Dockerfile` builds the common runtime used by the production Compose services. `docker/docker-compose.prod.yml` supplies the base stack; `docker/docker-compose.prod.wepp1.yml`, `docker/docker-compose.prod.wepp3.yml`, and `docker/docker-compose.prod.worker.yml` specialize host and worker behavior. These production files are protected inputs during this package.
+
+The minimum compatibility stack has three services. Caddy is the HTTP reverse proxy and static-file server. WEPPcloud is the Flask application served by Gunicorn on container port 8000. Redis is an in-memory key/value service used for Flask sessions; its smoke instance is ephemeral and isolated. The stack must contain no RQ worker and no Docker socket. Synthetic test-only secret values may be injected solely into the ephemeral local stack; production secret files must never be opened, copied, or generated.
+
+The image workflow lives as a manually triggerable and branch-capable workflow under `.github/workflows/`. It checks out the exact source commit, authenticates to `ghcr.io` with `github.actor` and `GITHUB_TOKEN`, builds `docker/Dockerfile` from repository context, tags the image using the full Git commit SHA, pushes it, and emits the digest. Workflow-level permissions are only `contents: read` and `packages: write`; every `uses:` reference is a 40-hex-character commit SHA.
+
+## Plan of Work
+
+First, record an inventory artifact that distinguishes the broad production contract from the web-only compatibility contract. Include services, internal and host ports, mounts, secret IDs (never values), health paths, Caddy routes, Docker sockets, image build arguments, and unresolved startup needs.
+
+Second, add the GHCR workflow. Use the existing repository root as build context and `docker/Dockerfile`; preserve its current default build arguments unless the compatibility matrix requires explicit existing values. Compute the image name in lowercase because GHCR names require lowercase. Use a tag formed only from the immutable full source commit, and expose the pushed digest through the job summary and job output.
+
+Third, add an independent smoke Compose file and minimum Caddyfile. The smoke stack builds or accepts the common image, uses only container-internal ports by default except a loopback-bound Caddy test port, uses disposable named volumes or temporary bind paths, and creates no Docker socket mount. Add a focused test script or pytest module that renders the model and asserts the forbidden surfaces remain absent. Exercise Caddy health, WEPPcloud health through the `/weppcloud/` proxy boundary, a static asset, and Redis isolation where startup permits.
+
+Finally, run focused repository checks and compare protected production files against the baseline commit with both Git diff and hashes. Review the complete patch for likely credentials, unpinned Actions, mutable workload tags, public binds, worker services, and socket mounts. Update the tracker, ExecPlan, inventory, and security review with exact evidence before committing and opening the PR.
+
+## Concrete Steps
+
+Work from `/home/roger/src/wepppy`.
+
+Inspect and render without production secrets:
+
+    docker compose -f docker/docker-compose.canary-smoke.yml config
+    <focused static test command selected during implementation>
+
+Build and smoke only the additive project, using an explicit project name that cannot collide with production:
+
+    docker compose --project-name weppcloud-canary-smoke -f docker/docker-compose.canary-smoke.yml build weppcloud
+    docker compose --project-name weppcloud-canary-smoke -f docker/docker-compose.canary-smoke.yml up --detach --wait
+    <HTTP checks>
+    docker compose --project-name weppcloud-canary-smoke -f docker/docker-compose.canary-smoke.yml down --volumes
+
+Validate protected files and the patch:
+
+    git diff --exit-code 2dedf916cb5ba430454dccc437ff0eb8fcb11daa -- docker/docker-compose.prod.yml docker/docker-compose.prod.wepp1.yml docker/docker-compose.prod.wepp3.yml docker/docker-compose.prod.worker.yml
+    git diff --check
+    wctl doc-lint --path docs/work-packages/20260813_weppcloud_private_canary_image
+
+Observed local results: build passed with local manifest digest `sha256:f70d212bd5d75ade2d183f807899bd00bf7f6c89b65029ae196dc53a1e626296`; the final HTTP checks returned `OK`, JSON string `"OK"`, the static compatibility text, and HTTP 200 for `/weppcloud/`. `/wc1` accepted a write, `/geodata` rejected one, and neither Redis nor WEPPcloud published a host port. The explicit project teardown removed its containers and networks; two stale volumes created by the first pre-`tmpfs` revision were removed by exact name.
+
+## Validation and Acceptance
+
+The Compose file must render without accessing `docker/secrets/`. Static assertions must show exactly Caddy, WEPPcloud, and Redis; no worker, Docker socket, host filesystem production mounts, external data credential, OAuth, SMTP, CAPTCHA, or public route may appear. Caddy `/health` and `/weppcloud/health` must return HTTP 200, `/weppcloud/` must traverse to the Flask application, and at least one packaged static asset must be served. Redis must be ephemeral and reachable only on the private Compose network.
+
+The workflow must parse as YAML, declare only the two required token permissions, contain no repository secret reference or personal token, pin all Actions by full SHA, build the existing common Dockerfile, use a full-SHA-derived image tag, push only from an authorized event, and report the immutable digest. A successful GitHub run and digest readback are required for full closeout; if publication is unavailable or fails, the package stays open and records the exact external blocker.
+
+All protected production Compose files must have an empty diff against source `2dedf916cb5ba430454dccc437ff0eb8fcb11daa`. Relevant focused tests and documentation lint must pass. The security artifact must contain no unresolved medium or high finding before the PR is declared ready for review.
+
+## Idempotence and Recovery
+
+The smoke stack uses the explicit project name `weppcloud-canary-smoke`; repeated render/build/up/down operations address only that isolated project. Always use `down --volumes` after runtime checks. If startup fails, capture `docker compose ... ps` and `docker compose ... logs --no-color`, then tear down only that explicit project. Never invoke `up`, `restart`, `down`, or `rm` against a production Compose file or an unspecified project.
+
+Workflow retries republish the same commit-derived manifest content under the same immutable source tag only when the build inputs are unchanged; reviewers consume the recorded digest, never the tag alone. Reverting the additive files removes this capability without affecting existing deployment files.
+
+## Artifacts and Notes
+
+Baseline source SHA:
+
+    2dedf916cb5ba430454dccc437ff0eb8fcb11daa
+
+Protected production Compose files:
+
+    docker/docker-compose.prod.yml
+    docker/docker-compose.prod.wepp1.yml
+    docker/docker-compose.prod.wepp3.yml
+    docker/docker-compose.prod.worker.yml
+
+## Interfaces and Dependencies
+
+Use Docker Compose v2 already installed on `dev-01`, Caddy's existing `caddy:2-alpine` family pinned to an immutable digest in the smoke workload, the current common `docker/Dockerfile`, and GitHub-hosted Actions pinned by commit. Do not add a language/runtime dependency. The future Kubernetes phase consumes the resulting common image strictly by `ghcr.io/<owner>/<image>@sha256:<digest>` and separately supplies reviewed runtime secrets and storage.
+
+Revision note (2026-08-13 19:36 UTC): Initial self-contained plan created from the dispatch, repository governance, and paired private-canary package.
+
+Revision note (2026-08-13 20:02 UTC): Recorded completed inventory/implementation/local validation, immutable publication inputs, observed startup/network surprises, and the remaining GitHub publication/PR milestone.

--- a/docs/work-packages/20260813_weppcloud_private_canary_image/prompts/active/weppcloud_private_canary_image_execplan.md
+++ b/docs/work-packages/20260813_weppcloud_private_canary_image/prompts/active/weppcloud_private_canary_image_execplan.md
@@ -16,7 +16,7 @@ After this work, reviewers can publish the repository's existing common WEPPpy r
 - [x] (2026-08-13 20:02 UTC) Build and exercise the image on `dev-01`; capture and resolve two smoke-only startup/network issues.
 - [x] (2026-08-13 20:02 UTC) Run focused checks, protected-file comparison, preliminary security review, and secret-sensitive diff review.
 - [x] (2026-08-13 20:20 UTC) Commit/push, observe successful publication, pull and smoke the exact digest, and finalize security evidence.
-- [ ] Open a ready-for-review PR and record its URL.
+- [x] (2026-08-13 20:25 UTC) Open ready-for-review PR https://github.com/rogerlew/wepppy/pull/611 and record its URL.
 
 ## Surprises & Discoveries
 
@@ -54,7 +54,7 @@ After this work, reviewers can publish the repository's existing common WEPPpy r
 
 ## Outcomes & Retrospective
 
-Implementation and artifact acceptance are complete. GitHub run `31739217249` published source `ed1b538df02a8db0d709257ea9dacc330c56b9d9` as `ghcr.io/rogerlew/wepppy:sha-ed1b538df02a8db0d709257ea9dacc330c56b9d9` with digest `sha256:ee92666229df8fdffe4b06b1dff2cfd0e9e06823ada59915c8b492d8a468eb51`. The exact digest passed the three-service runtime contract and the security gate. Only PR creation remains.
+Implementation and artifact acceptance are complete. GitHub run `31739217249` published source `ed1b538df02a8db0d709257ea9dacc330c56b9d9` as `ghcr.io/rogerlew/wepppy:sha-ed1b538df02a8db0d709257ea9dacc330c56b9d9` with digest `sha256:ee92666229df8fdffe4b06b1dff2cfd0e9e06823ada59915c8b492d8a468eb51`. The exact digest passed the three-service runtime contract and the security gate. PR https://github.com/rogerlew/wepppy/pull/611 is ready for review.
 
 ## Context and Orientation
 
@@ -138,3 +138,5 @@ Revision note (2026-08-13 20:02 UTC): Recorded completed inventory/implementatio
 Revision note (2026-08-13 20:07 UTC): Recorded the first CI build's global Dockerfile ARG failure and its minimal scope correction; publication remains pending retry.
 
 Revision note (2026-08-13 20:20 UTC): Recorded successful GHCR publication, exact tag/digest, authenticated pull, anonymous privacy probe, digest-pinned runtime acceptance, and final security sign-off.
+
+Revision note (2026-08-13 20:25 UTC): Recorded ready-for-review PR #611 and completed every planned non-live milestone.

--- a/docs/work-packages/20260813_weppcloud_private_canary_image/prompts/active/weppcloud_private_canary_image_execplan.md
+++ b/docs/work-packages/20260813_weppcloud_private_canary_image/prompts/active/weppcloud_private_canary_image_execplan.md
@@ -15,7 +15,8 @@ After this work, reviewers can publish the repository's existing common WEPPpy r
 - [x] (2026-08-13 20:02 UTC) Implement additive Compose/Caddy smoke configuration and focused assertions.
 - [x] (2026-08-13 20:02 UTC) Build and exercise the image on `dev-01`; capture and resolve two smoke-only startup/network issues.
 - [x] (2026-08-13 20:02 UTC) Run focused checks, protected-file comparison, preliminary security review, and secret-sensitive diff review.
-- [ ] Commit, push, open a ready-for-review PR, observe workflow publication, and record tag/digest.
+- [x] (2026-08-13 20:20 UTC) Commit/push, observe successful publication, pull and smoke the exact digest, and finalize security evidence.
+- [ ] Open a ready-for-review PR and record its URL.
 
 ## Surprises & Discoveries
 
@@ -32,7 +33,10 @@ After this work, reviewers can publish the repository's existing common WEPPpy r
   Evidence: Caddy was healthy and its HostConfig listed port 18080, but NetworkSettings had no published port and host curl failed. Attaching only Caddy to a second edge network made `127.0.0.1:18080` reachable while Redis/web remained internal.
 
 - Observation: Dockerfile build arguments used by multiple `FROM` instructions must be declared before the first `FROM` to remain globally available.
-  Evidence: GitHub run `31739044295` failed with `base name (${RUNTIME_BASE_IMAGE}) should not be blank`. Moving both image arguments above the first stage fixes their BuildKit scope; a retry is pending.
+  Evidence: GitHub run `31739044295` failed with `base name (${RUNTIME_BASE_IMAGE}) should not be blank`. Moving both image arguments above the first stage fixed their BuildKit scope; run `31739217249` then succeeded.
+
+- Observation: GitHub's package metadata API requires a `read:packages` user-token scope that the local token does not carry, but registry authentication and artifact pull use the workflow-created package authorization successfully.
+  Evidence: the metadata API returned 403, authenticated digest pull succeeded, and an anonymous manifest request returned 401. No repository or package setting was changed.
 
 ## Decision Log
 
@@ -50,7 +54,7 @@ After this work, reviewers can publish the repository's existing common WEPPpy r
 
 ## Outcomes & Retrospective
 
-The local implementation and runtime evidence are complete. The existing common image builds and the minimum three-service stack passes the intended HTTP, storage, Redis, and negative-boundary checks. GitHub publication, private-package/digest readback, final security sign-off, and the PR remain.
+Implementation and artifact acceptance are complete. GitHub run `31739217249` published source `ed1b538df02a8db0d709257ea9dacc330c56b9d9` as `ghcr.io/rogerlew/wepppy:sha-ed1b538df02a8db0d709257ea9dacc330c56b9d9` with digest `sha256:ee92666229df8fdffe4b06b1dff2cfd0e9e06823ada59915c8b492d8a468eb51`. The exact digest passed the three-service runtime contract and the security gate. Only PR creation remains.
 
 ## Context and Orientation
 
@@ -94,6 +98,8 @@ Validate protected files and the patch:
 
 Observed local results: build passed with local manifest digest `sha256:f70d212bd5d75ade2d183f807899bd00bf7f6c89b65029ae196dc53a1e626296`; the final HTTP checks returned `OK`, JSON string `"OK"`, the static compatibility text, and HTTP 200 for `/weppcloud/`. `/wc1` accepted a write, `/geodata` rejected one, and neither Redis nor WEPPcloud published a host port. The explicit project teardown removed its containers and networks; two stale volumes created by the first pre-`tmpfs` revision were removed by exact name.
 
+Published-artifact results: run `31739217249` succeeded in 7m22s. An authenticated pull of `ghcr.io/rogerlew/wepppy@sha256:ee92666229df8fdffe4b06b1dff2cfd0e9e06823ada59915c8b492d8a468eb51` succeeded; the exact image then passed the same HTTP, storage, socket, port, and cleanup checks. Anonymous manifest access returned 401.
+
 ## Validation and Acceptance
 
 The Compose file must render without accessing `docker/secrets/`. Static assertions must show exactly Caddy, WEPPcloud, and Redis; no worker, Docker socket, host filesystem production mounts, external data credential, OAuth, SMTP, CAPTCHA, or public route may appear. Caddy `/health` and `/weppcloud/health` must return HTTP 200, `/weppcloud/` must traverse to the Flask application, and at least one packaged static asset must be served. Redis must be ephemeral and reachable only on the private Compose network.
@@ -130,3 +136,5 @@ Revision note (2026-08-13 19:36 UTC): Initial self-contained plan created from t
 Revision note (2026-08-13 20:02 UTC): Recorded completed inventory/implementation/local validation, immutable publication inputs, observed startup/network surprises, and the remaining GitHub publication/PR milestone.
 
 Revision note (2026-08-13 20:07 UTC): Recorded the first CI build's global Dockerfile ARG failure and its minimal scope correction; publication remains pending retry.
+
+Revision note (2026-08-13 20:20 UTC): Recorded successful GHCR publication, exact tag/digest, authenticated pull, anonymous privacy probe, digest-pinned runtime acceptance, and final security sign-off.

--- a/docs/work-packages/20260813_weppcloud_private_canary_image/prompts/active/weppcloud_private_canary_image_execplan.md
+++ b/docs/work-packages/20260813_weppcloud_private_canary_image/prompts/active/weppcloud_private_canary_image_execplan.md
@@ -31,6 +31,9 @@ After this work, reviewers can publish the repository's existing common WEPPpy r
 - Observation: Docker did not activate a loopback port publish while Caddy was attached only to an `internal: true` network.
   Evidence: Caddy was healthy and its HostConfig listed port 18080, but NetworkSettings had no published port and host curl failed. Attaching only Caddy to a second edge network made `127.0.0.1:18080` reachable while Redis/web remained internal.
 
+- Observation: Dockerfile build arguments used by multiple `FROM` instructions must be declared before the first `FROM` to remain globally available.
+  Evidence: GitHub run `31739044295` failed with `base name (${RUNTIME_BASE_IMAGE}) should not be blank`. Moving both image arguments above the first stage fixes their BuildKit scope; a retry is pending.
+
 ## Decision Log
 
 - Decision: Implement a standalone compatibility Compose file instead of an override layered onto production Compose.
@@ -125,3 +128,5 @@ Use Docker Compose v2 already installed on `dev-01`, Caddy's existing `caddy:2-a
 Revision note (2026-08-13 19:36 UTC): Initial self-contained plan created from the dispatch, repository governance, and paired private-canary package.
 
 Revision note (2026-08-13 20:02 UTC): Recorded completed inventory/implementation/local validation, immutable publication inputs, observed startup/network surprises, and the remaining GitHub publication/PR milestone.
+
+Revision note (2026-08-13 20:07 UTC): Recorded the first CI build's global Dockerfile ARG failure and its minimal scope correction; publication remains pending retry.

--- a/docs/work-packages/20260813_weppcloud_private_canary_image/tracker.md
+++ b/docs/work-packages/20260813_weppcloud_private_canary_image/tracker.md
@@ -4,9 +4,9 @@
 
 **Timezone**: UTC
 **Started**: 2026-08-13 19:36 UTC
-**Current phase**: Publication evidence
-**Last updated**: 2026-08-13 20:02 UTC
-**Next milestone**: Push the branch, read back the private GHCR digest, and finalize the PR
+**Current phase**: Ready-for-review handoff
+**Last updated**: 2026-08-13 20:20 UTC
+**Next milestone**: Open the ready-for-review PR and capture its URL
 **Security impact**: `high`
 **Dedicated security review**: `yes`
 **Security artifact**: `docs/work-packages/20260813_weppcloud_private_canary_image/artifacts/2026-08-13_security_review.md`
@@ -15,12 +15,11 @@
 
 ### Ready / Backlog
 
-- [ ] Finalize security review and governance with GHCR readback.
 - [ ] Open a ready-for-review PR and capture its URL.
 
 ### In Progress
 
-- [ ] Commit and push the branch; capture workflow image tag/digest/privacy evidence.
+- [ ] None.
 
 ### Blocked
 
@@ -35,11 +34,14 @@
 - [x] Built the common image and passed isolated Caddy + WEPPcloud + Redis runtime smoke checks (2026-08-13 20:02 UTC).
 - [x] Proved protected production Compose/Caddy files have an empty baseline diff (2026-08-13 20:02 UTC).
 - [x] Completed preliminary security and secret-sensitive diff review; final GHCR readback remains (2026-08-13 20:02 UTC).
+- [x] Published source `ed1b538df02a8db0d709257ea9dacc330c56b9d9`, read back digest `sha256:ee92666229df8fdffe4b06b1dff2cfd0e9e06823ada59915c8b492d8a468eb51`, and passed the digest-pinned smoke (2026-08-13 20:20 UTC).
+- [x] Finalized the dedicated security review with no unresolved medium/high implementation findings (2026-08-13 20:20 UTC).
 
 ## Timeline
 
 - **2026-08-13 19:36 UTC** – Package created; non-live implementation began.
 - **2026-08-13 20:02 UTC** – Local image build and isolated runtime compatibility passed; publication evidence began.
+- **2026-08-13 20:20 UTC** – GHCR run `31739217249` succeeded; exact digest pull, privacy probe, runtime smoke, and teardown passed.
 
 ## Decisions Log
 
@@ -63,8 +65,8 @@
 
 | Risk | Severity | Likelihood | Mitigation | Status |
 | --- | --- | --- | --- | --- |
-| Shared runtime image build regresses production consumers | High | Medium | Build common Dockerfile, retain default args, and record production-file hashes/diff | Mitigated; CI run pending |
-| Workflow authority or tags are broader/mutable | High | Medium | Minimum permissions, full Action SHAs, commit tag, digest output, private package readback | CI readback pending |
+| Shared runtime image build regresses production consumers | High | Medium | Build common Dockerfile, retain default args, and record production-file hashes/diff | Mitigated; CI and smoke passed |
+| Workflow authority or tags are broader/mutable | High | Medium | Minimum permissions, full Action SHAs, commit tag, digest output, private package readback | Mitigated; run/readback passed |
 | Flask startup requires more services/secrets than the minimum design | High | Medium | Synthetic inputs and `/dev/null` for legacy Discord import; PostgreSQL explicitly deferred | Mitigated/documented |
 | Smoke stack accidentally includes workers/socket/public exposure | High | Low | Static assertions, rendered negative checks, loopback-only edge | Closed |
 
@@ -78,15 +80,15 @@
 
 ### Security
 
-- [ ] Dedicated security review has no unresolved medium/high findings.
+- [x] Dedicated security review has no unresolved medium/high implementation findings.
 - [x] No production secret was accessed or retained.
 - [x] Secret-sensitive diff review passes.
 
 ### Documentation
 
 - [x] Compatibility inventory and matrix record exact contracts and evidence.
-- [ ] Active ExecPlan and tracker reflect final state (publication/PR pending).
-- [ ] Exact source SHA, image tag/digest, permissions, inputs, tests, and startup needs are recorded (GHCR digest pending).
+- [x] Active ExecPlan and tracker reflect final state (PR creation pending).
+- [x] Exact source SHA, image tag/digest, permissions, inputs, tests, and startup needs are recorded.
 
 ### Testing
 
@@ -131,7 +133,24 @@
 
 **Next steps**: Commit/push, observe GHCR workflow, verify privacy and digest, remove the transient feature-branch push trigger, finalize governance, and open the PR.
 
-**Test results**: Local build pass; runtime smoke pass; static contracts 2 pass; focused pytest 1 pass/1 deselected; Caddy valid; protected diff and secret-pattern check pass. GitHub run `31739044295` failed with the exact global-ARG issue above; retry pending.
+**Test results**: Local build pass; runtime smoke pass; static contracts 2 pass; focused pytest 1 pass/1 deselected; Caddy valid; protected diff and secret-pattern check pass. GitHub run `31739044295` failed with the exact global-ARG issue above; corrected run `31739217249` passed.
+
+### 2026-08-13 20:20 UTC: Published-artifact acceptance
+
+**Agent/Contributor**: Codex
+
+**Work completed**:
+
+- GitHub run `31739217249` published `ghcr.io/rogerlew/wepppy:sha-ed1b538df02a8db0d709257ea9dacc330c56b9d9` at digest `sha256:ee92666229df8fdffe4b06b1dff2cfd0e9e06823ada59915c8b492d8a468eb51`.
+- Authenticated digest pull succeeded; anonymous manifest access returned HTTP 401 without changing package settings.
+- The exact digest passed health, proxy, static, root, storage-permission, no-socket, and loopback-only port checks; explicit teardown left no project containers or networks.
+- Removed the temporary feature-branch publish trigger; the final workflow supports manual dispatch and pushes to `master` only.
+
+**Blockers encountered**: The local GitHub token lacks `read:packages`, so GitHub's package metadata API returned 403. Authenticated pull plus the anonymous 401 probe supplied the required artifact and privacy evidence.
+
+**Next steps**: Run final diff/lint checks, commit, push, and open the ready-for-review PR.
+
+**Test results**: GitHub publish pass; exact digest pull/runtime pass; privacy probe pass; cleanup pass. The published image's local compressed-content size reported by Docker is 2,195,646,167 bytes.
 
 ## Watch List
 

--- a/docs/work-packages/20260813_weppcloud_private_canary_image/tracker.md
+++ b/docs/work-packages/20260813_weppcloud_private_canary_image/tracker.md
@@ -127,10 +127,11 @@
 - `wctl` is not installed on `dev-01`, despite the documented baseline. Focused checks ran directly and one pytest selection ran inside the built image.
 - Initial web startup failed because a vendored Discord module opens a fixed token path; `/dev/null` satisfies the import without a credential.
 - An internal-only network suppressed the host loopback publish; the final design attaches only Caddy to a loopback edge network while Redis/web remain on the internal backend.
+- First GitHub run `31739044295` failed before compilation because `RUNTIME_BASE_IMAGE` was declared after the first Dockerfile stage and was blank in the second `FROM`; both base arguments were moved to global Dockerfile scope for the retry.
 
 **Next steps**: Commit/push, observe GHCR workflow, verify privacy and digest, remove the transient feature-branch push trigger, finalize governance, and open the PR.
 
-**Test results**: Local build pass; runtime smoke pass; static contracts 2 pass; focused pytest 1 pass/1 deselected; Caddy valid; protected diff and secret-pattern check pass.
+**Test results**: Local build pass; runtime smoke pass; static contracts 2 pass; focused pytest 1 pass/1 deselected; Caddy valid; protected diff and secret-pattern check pass. GitHub run `31739044295` failed with the exact global-ARG issue above; retry pending.
 
 ## Watch List
 

--- a/docs/work-packages/20260813_weppcloud_private_canary_image/tracker.md
+++ b/docs/work-packages/20260813_weppcloud_private_canary_image/tracker.md
@@ -4,9 +4,9 @@
 
 **Timezone**: UTC
 **Started**: 2026-08-13 19:36 UTC
-**Current phase**: Ready-for-review handoff
-**Last updated**: 2026-08-13 20:20 UTC
-**Next milestone**: Open the ready-for-review PR and capture its URL
+**Current phase**: Review
+**Last updated**: 2026-08-13 20:25 UTC
+**Next milestone**: Reviewer disposition of PR #611
 **Security impact**: `high`
 **Dedicated security review**: `yes`
 **Security artifact**: `docs/work-packages/20260813_weppcloud_private_canary_image/artifacts/2026-08-13_security_review.md`
@@ -15,7 +15,7 @@
 
 ### Ready / Backlog
 
-- [ ] Open a ready-for-review PR and capture its URL.
+- [ ] None.
 
 ### In Progress
 
@@ -36,12 +36,14 @@
 - [x] Completed preliminary security and secret-sensitive diff review; final GHCR readback remains (2026-08-13 20:02 UTC).
 - [x] Published source `ed1b538df02a8db0d709257ea9dacc330c56b9d9`, read back digest `sha256:ee92666229df8fdffe4b06b1dff2cfd0e9e06823ada59915c8b492d8a468eb51`, and passed the digest-pinned smoke (2026-08-13 20:20 UTC).
 - [x] Finalized the dedicated security review with no unresolved medium/high implementation findings (2026-08-13 20:20 UTC).
+- [x] Opened ready-for-review PR https://github.com/rogerlew/wepppy/pull/611 (2026-08-13 20:25 UTC).
 
 ## Timeline
 
 - **2026-08-13 19:36 UTC** – Package created; non-live implementation began.
 - **2026-08-13 20:02 UTC** – Local image build and isolated runtime compatibility passed; publication evidence began.
 - **2026-08-13 20:20 UTC** – GHCR run `31739217249` succeeded; exact digest pull, privacy probe, runtime smoke, and teardown passed.
+- **2026-08-13 20:25 UTC** – Opened ready-for-review PR #611.
 
 ## Decisions Log
 
@@ -151,6 +153,18 @@
 **Next steps**: Run final diff/lint checks, commit, push, and open the ready-for-review PR.
 
 **Test results**: GitHub publish pass; exact digest pull/runtime pass; privacy probe pass; cleanup pass. The published image's local compressed-content size reported by Docker is 2,195,646,167 bytes.
+
+### 2026-08-13 20:25 UTC: Review handoff
+
+**Agent/Contributor**: Codex
+
+**Work completed**: Opened ready-for-review PR https://github.com/rogerlew/wepppy/pull/611 with exact artifact and validation evidence.
+
+**Blockers encountered**: None for this phase.
+
+**Next steps**: Reviewer disposition; live Kubernetes work remains explicitly out of scope.
+
+**Test results**: Final scoped diff and PR state verified.
 
 ## Watch List
 

--- a/docs/work-packages/20260813_weppcloud_private_canary_image/tracker.md
+++ b/docs/work-packages/20260813_weppcloud_private_canary_image/tracker.md
@@ -1,0 +1,138 @@
+# Tracker – WEPPcloud private-canary image compatibility
+
+## Quick Status
+
+**Timezone**: UTC
+**Started**: 2026-08-13 19:36 UTC
+**Current phase**: Publication evidence
+**Last updated**: 2026-08-13 20:02 UTC
+**Next milestone**: Push the branch, read back the private GHCR digest, and finalize the PR
+**Security impact**: `high`
+**Dedicated security review**: `yes`
+**Security artifact**: `docs/work-packages/20260813_weppcloud_private_canary_image/artifacts/2026-08-13_security_review.md`
+
+## Task Board
+
+### Ready / Backlog
+
+- [ ] Finalize security review and governance with GHCR readback.
+- [ ] Open a ready-for-review PR and capture its URL.
+
+### In Progress
+
+- [ ] Commit and push the branch; capture workflow image tag/digest/privacy evidence.
+
+### Blocked
+
+- [ ] None.
+
+### Done
+
+- [x] Read repository, Docker/workflow, ExecPlan, and paired-package governance (2026-08-13 19:36 UTC).
+- [x] Created branch `weppcloud-private-canary-image` from `2dedf916cb5ba430454dccc437ff0eb8fcb11daa` (2026-08-13 19:36 UTC).
+- [x] Completed production inventory and compatibility matrix (2026-08-13 20:02 UTC).
+- [x] Implemented the minimal-permission, full-SHA-pinned GHCR workflow and immutable build inputs (2026-08-13 20:02 UTC).
+- [x] Built the common image and passed isolated Caddy + WEPPcloud + Redis runtime smoke checks (2026-08-13 20:02 UTC).
+- [x] Proved protected production Compose/Caddy files have an empty baseline diff (2026-08-13 20:02 UTC).
+- [x] Completed preliminary security and secret-sensitive diff review; final GHCR readback remains (2026-08-13 20:02 UTC).
+
+## Timeline
+
+- **2026-08-13 19:36 UTC** – Package created; non-live implementation began.
+- **2026-08-13 20:02 UTC** – Local image build and isolated runtime compatibility passed; publication evidence began.
+
+## Decisions Log
+
+### 2026-08-13 19:36 UTC: Additive web-only compatibility surface
+
+**Context**: Production Compose includes many auxiliary services, workers, persistent data, and secrets that are prohibited or unnecessary for this phase.
+
+**Decision**: Add a standalone Caddy + WEPPcloud + ephemeral Redis smoke contract and leave every existing production Compose file untouched.
+
+**Impact**: The phase can prove image and web-route compatibility without production mutation, Docker socket access, workers, or durable Redis.
+
+### 2026-08-13 20:02 UTC: Pin publication inputs without changing Compose defaults
+
+**Context**: The existing Dockerfile accepts sibling-repository refs but defaulted to branches and used floating base/installer inputs.
+
+**Decision**: Add default-preserving Dockerfile arguments for base images, uv, and Rosetta, then supply digests/versioned URL/full Git SHAs only from the publication workflow.
+
+**Impact**: Normal production Compose builds retain their current defaults. The publication run records substantially tighter immutable inputs and always reports the final manifest digest; Debian/DuckDB network resolution remains a documented non-hermetic limit.
+
+## Risks and Issues
+
+| Risk | Severity | Likelihood | Mitigation | Status |
+| --- | --- | --- | --- | --- |
+| Shared runtime image build regresses production consumers | High | Medium | Build common Dockerfile, retain default args, and record production-file hashes/diff | Mitigated; CI run pending |
+| Workflow authority or tags are broader/mutable | High | Medium | Minimum permissions, full Action SHAs, commit tag, digest output, private package readback | CI readback pending |
+| Flask startup requires more services/secrets than the minimum design | High | Medium | Synthetic inputs and `/dev/null` for legacy Discord import; PostgreSQL explicitly deferred | Mitigated/documented |
+| Smoke stack accidentally includes workers/socket/public exposure | High | Low | Static assertions, rendered negative checks, loopback-only edge | Closed |
+
+## Verification Checklist
+
+### Code Quality
+
+- [x] Focused tests pass.
+- [x] Workflow and Compose lint/render checks pass.
+- [x] No unpinned Actions or new dependency were introduced; existing npm findings recorded.
+
+### Security
+
+- [ ] Dedicated security review has no unresolved medium/high findings.
+- [x] No production secret was accessed or retained.
+- [x] Secret-sensitive diff review passes.
+
+### Documentation
+
+- [x] Compatibility inventory and matrix record exact contracts and evidence.
+- [ ] Active ExecPlan and tracker reflect final state (publication/PR pending).
+- [ ] Exact source SHA, image tag/digest, permissions, inputs, tests, and startup needs are recorded (GHCR digest pending).
+
+### Testing
+
+- [x] Additive Compose config renders.
+- [x] Runtime smoke passes; first-start failures and resolutions are captured.
+- [x] Protected production Compose files are byte-for-byte unchanged.
+
+## Progress Notes
+
+### 2026-08-13 19:36 UTC: Governance and baseline
+
+**Agent/Contributor**: Codex
+
+**Work completed**:
+
+- Read applicable root, Docker, workflow, work-package, and ExecPlan instructions.
+- Read the paired `open-wepp-org` package, tracker, security review, and dispatch.
+- Confirmed a clean `master` baseline and created the authorized feature branch.
+
+**Blockers encountered**: None.
+
+**Next steps**: Finish the exact inventory, then implement the additive workflow and smoke harness.
+
+**Test results**: No implementation tests run yet.
+
+### 2026-08-13 20:02 UTC: Local implementation and validation
+
+**Agent/Contributor**: Codex
+
+**Work completed**:
+
+- Added publication workflow, immutable build-input hooks, additive smoke Compose/Caddy configuration, static contract tests, inventory, and security review.
+- Built a 2,663,253,220-byte local image and obtained local manifest digest `sha256:f70d212bd5d75ade2d183f807899bd00bf7f6c89b65029ae196dc53a1e626296`.
+- Passed health, root, static, Redis, filesystem, port, socket, and teardown checks.
+
+**Blockers encountered**:
+
+- `wctl` is not installed on `dev-01`, despite the documented baseline. Focused checks ran directly and one pytest selection ran inside the built image.
+- Initial web startup failed because a vendored Discord module opens a fixed token path; `/dev/null` satisfies the import without a credential.
+- An internal-only network suppressed the host loopback publish; the final design attaches only Caddy to a loopback edge network while Redis/web remain on the internal backend.
+
+**Next steps**: Commit/push, observe GHCR workflow, verify privacy and digest, remove the transient feature-branch push trigger, finalize governance, and open the PR.
+
+**Test results**: Local build pass; runtime smoke pass; static contracts 2 pass; focused pytest 1 pass/1 deselected; Caddy valid; protected diff and secret-pattern check pass.
+
+## Watch List
+
+- **GHCR visibility**: workflow publication must not change repository/package settings; existing GitHub defaults must yield a private package.
+- **Image size/build duration**: capture the precise failure if a complete build cannot finish on `dev-01`.

--- a/tests/docker/test_canary_smoke_contract.py
+++ b/tests/docker/test_canary_smoke_contract.py
@@ -73,10 +73,7 @@ def test_workflow_has_minimum_permissions_immutable_tags_and_pinned_actions() ->
 
     assert workflow["permissions"] == {"contents": "read", "packages": "write"}
     assert "workflow_dispatch" in workflow[True]
-    assert workflow[True]["push"]["branches"] == [
-        "master",
-        "weppcloud-private-canary-image",
-    ]
+    assert workflow[True]["push"]["branches"] == ["master"]
     assert "secrets.GITHUB_TOKEN" in workflow_text
     assert "sha-${GITHUB_SHA}" in workflow_text
     assert "steps.build.outputs.digest" in workflow_text

--- a/tests/docker/test_canary_smoke_contract.py
+++ b/tests/docker/test_canary_smoke_contract.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMPOSE_FILE = REPO_ROOT / "docker" / "docker-compose.canary-smoke.yml"
+WORKFLOW_FILE = REPO_ROOT / ".github" / "workflows" / "publish-weppcloud-image.yml"
+FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
+
+
+def _smoke_environment() -> dict[str, str]:
+    return {
+        **os.environ,
+        "WEPPCLOUD_SMOKE_IMAGE": "wepppy-canary-smoke:sha-" + ("a" * 40),
+        "WEPPCLOUD_SMOKE_REDIS_PASSWORD": "ephemeral-test-only-redis",
+        "WEPPCLOUD_SMOKE_SECRET_KEY": "ephemeral-test-only-flask-key",
+        "WEPPCLOUD_SMOKE_PASSWORD_SALT": "ephemeral-test-only-salt",
+        "WEPPCLOUD_SMOKE_AGENT_JWT_SECRET": "ephemeral-test-only-agent-jwt",
+    }
+
+
+def test_compose_contract_renders_only_minimum_isolated_services() -> None:
+    result = subprocess.run(
+        ["docker", "compose", "-f", str(COMPOSE_FILE), "config", "--format", "json"],
+        cwd=REPO_ROOT,
+        env=_smoke_environment(),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    model = __import__("json").loads(result.stdout)
+
+    assert set(model["services"]) == {"caddy", "redis", "weppcloud"}
+    assert model["networks"]["canary"]["internal"] is True
+    assert model["services"]["caddy"]["networks"] == {"canary": None, "edge": None}
+    assert model["services"]["redis"]["networks"] == {"canary": None}
+    assert model["services"]["weppcloud"]["networks"] == {"canary": None}
+    assert "ports" not in model["services"]["redis"]
+    assert "ports" not in model["services"]["weppcloud"]
+    assert model["services"]["caddy"]["ports"][0]["host_ip"] == "127.0.0.1"
+    assert model["secrets"]["disabled-discord-token"]["file"] == "/dev/null"
+    assert model["services"]["weppcloud"]["tmpfs"] == [
+        "/wc1:uid=1000,gid=993,mode=0770",
+        "/geodata:uid=1000,gid=993,mode=0550",
+    ]
+
+    rendered = result.stdout.lower()
+    for forbidden in (
+        "docker.sock",
+        "rq-worker",
+        "oauth_",
+        "smtp",
+        "captcha",
+        "opentopography",
+        "climate_engine",
+        "/wc1:/wc1",
+        "/geodata:/geodata",
+    ):
+        assert forbidden not in rendered
+
+
+def test_workflow_has_minimum_permissions_immutable_tags_and_pinned_actions() -> None:
+    workflow_text = WORKFLOW_FILE.read_text(encoding="utf-8")
+    workflow = yaml.safe_load(workflow_text)
+
+    assert workflow["permissions"] == {"contents": "read", "packages": "write"}
+    assert "workflow_dispatch" in workflow[True]
+    assert workflow[True]["push"]["branches"] == [
+        "master",
+        "weppcloud-private-canary-image",
+    ]
+    assert "secrets.GITHUB_TOKEN" in workflow_text
+    assert "sha-${GITHUB_SHA}" in workflow_text
+    assert "steps.build.outputs.digest" in workflow_text
+    assert "docker/Dockerfile" in workflow_text
+    assert "context: ." in workflow_text
+    assert "RUNTIME_BASE_IMAGE=python:3.12-slim@sha256:" in workflow_text
+    assert "STATIC_BUILDER_IMAGE=node:20-alpine@sha256:" in workflow_text
+    assert "UV_INSTALLER_URL=https://astral.sh/uv/0.12.3/install.sh" in workflow_text
+    for build_arg in (
+        "ROSETTA_REF",
+        "WEPPCLOUD2_REF",
+        "F_ESRI_REF",
+        "WBT_REF",
+        "WEPPPYO3_REF",
+    ):
+        assert re.search(rf"^\s*{build_arg}=[0-9a-f]{{40}}$", workflow_text, re.MULTILINE)
+
+    uses = re.findall(r"^\s*uses:\s*([^\s#]+)", workflow_text, flags=re.MULTILINE)
+    assert uses
+    for action in uses:
+        _, separator, revision = action.partition("@")
+        assert separator == "@"
+        assert FULL_SHA.fullmatch(revision), action
+
+    assert re.search(r"(?:^|:)\s*(?:latest|main|master)\s*$", workflow_text, re.MULTILINE) is None


### PR DESCRIPTION
## Summary
- publish the existing common runtime image to private GHCR with minimum GITHUB_TOKEN permissions, full-SHA-pinned Actions, commit-derived tags, and digest reporting
- add an isolated Caddy + WEPPcloud + ephemeral Redis compatibility stack and focused contract tests
- record governed inventory, security review, production non-mutation evidence, and exact artifact acceptance

## Published artifact
- source: ed1b538df02a8db0d709257ea9dacc330c56b9d9
- tag: ghcr.io/rogerlew/wepppy:sha-ed1b538df02a8db0d709257ea9dacc330c56b9d9
- digest: sha256:ee92666229df8fdffe4b06b1dff2cfd0e9e06823ada59915c8b492d8a468eb51
- workflow run: https://github.com/rogerlew/wepppy/actions/runs/31739217249

## Validation
- exact digest pull and three-service runtime smoke passed
- health, proxy, static, root, Redis, storage permissions, no-socket, and loopback-only exposure checks passed
- focused workflow contract pytest passed
- additive Compose render, YAML parse, git diff --check, and secret-sensitive diff scan passed
- protected production Compose/Caddy files have an empty diff from baseline
- dedicated security gate passed with no unresolved medium/high implementation findings

## Constraints preserved
No production or test-production stack was deployed or restarted. No production secrets or infrastructure credentials were accessed. Existing production Compose files and deployment workflows are unchanged.

## Known limitations
- wctl and host pytest are unavailable on dev-01; focused pytest ran inside the immutable runtime image
- the local user token lacks read:packages for package-metadata API readback; authenticated digest pull succeeded and anonymous manifest access returned 401
- pre-existing npm audit findings and non-hermetic Debian/DuckDB resolution are documented in the security artifact