### PR TITLE
Document WEPPcloud web runtime contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,7 @@
 - NoDb facade/collaborator implementation standard: `docs/standards/nodb-facade-collaborator-pattern.md`
 - Vulture dead-code gate standard: `docs/standards/vulture-dead-code-gate-standard.md`
 - WBT release cutover reference (includes canonical `weppcloud-wbt` runbook link): `docs/dev-notes/weppcloud-wbt-release-cutover.md`
-- Docker/local secret conventions: `docker/secrets/README.md`
+- Docker/local secrets: `docker/secrets/README.md`; WEPPcloud web startup/minimum secret contract: `docs/infrastructure/weppcloud-web-runtime-contract.md`
 
 ## Subsystem Maps (Nearest AGENTS Wins)
 - WEPP binary vendoring and observability debugging: `wepp_runner/AGENTS.md`

--- a/docker/README.md
+++ b/docker/README.md
@@ -5,6 +5,10 @@
 This guide covers both the development (`docker-compose.dev.yml`) and production (`docker-compose.prod.yml`) Docker Compose stacks for WEPPcloud.
 It also covers the production worker pool stack (`docker-compose.prod.worker.yml`) used on dedicated RQ worker hosts.
 
+The canonical web-process startup, minimum configuration, and secret inventory
+is documented in
+[`docs/infrastructure/weppcloud-web-runtime-contract.md`](../docs/infrastructure/weppcloud-web-runtime-contract.md).
+
 `docker-compose.dev.hpc.yml` is a legacy configuration that is being
 repurposed. It is not a supported WEPPcloud development or worker deployment
 target; do not extend new worker topology into it unless its replacement

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ This directory holds top-level documentation that supports the codebase. Use the
 Prefer to keep documentation alongside the relevant source module when practical. Use the `docs/` tree for cross-cutting references, UI guidance, or coordinated efforts (work packages and mini packages).
 
 ## Canonical Contracts
+- WEPPcloud web startup and minimum secrets: `docs/infrastructure/weppcloud-web-runtime-contract.md`
 - CSRF: `docs/schemas/weppcloud-csrf-contract.md`
 - Browser/session lifecycle: `docs/schemas/weppcloud-session-contract.md`
 - JWT/auth claims and token classes: `docs/dev-notes/auth-token.spec.md`

--- a/docs/infrastructure/weppcloud-web-runtime-contract.md
+++ b/docs/infrastructure/weppcloud-web-runtime-contract.md
@@ -1,0 +1,182 @@
+# WEPPcloud web runtime contract
+
+This is the canonical startup and secret inventory for the WEPPcloud web
+process. It applies to Docker Compose and Kubernetes. Deployment-specific
+documents may add configuration, but they must not silently weaken or replace
+this contract.
+
+The Kubernetes deployment is greenfield. Existing production Compose
+deployments on `wepp1`, `wepp2`, and `wepp3` remain independent and must keep
+their current defaults unless a separate production change explicitly says
+otherwise.
+
+## Process contract
+
+The common image starts through `docker/weppcloud-entrypoint.sh`, which performs
+the tracked JavaScript and native-library preflights before executing the
+container command. The web process is Gunicorn serving
+`wepppy.weppcloud.app:app` on port `8000`.
+
+The production image default is four workers, two threads, and a 1,800-second
+timeout. A resource-bounded canary may override that to one worker, two threads,
+and a 120-second timeout without changing the image or Compose defaults:
+
+```text
+gunicorn --workers 1 --threads 2 --timeout 120 \
+  --bind 0.0.0.0:8000 --log-level info wepppy.weppcloud.app:app
+```
+
+Use `GET /health` for container readiness and liveness. A gateway may expose the
+application under `SITE_PREFIX`, but it must strip the prefix before proxying and
+set `X-Forwarded-Prefix`, matching the current Caddy behavior. Kubernetes will
+move proven routes incrementally to Traefik/Gateway API; Caddy is a temporary
+compatibility layer, not the target public ingress.
+
+## Minimum web-only configuration
+
+These values are sufficient for a web-only canary with local login and optional
+integrations disabled. Example values are non-secret and illustrative.
+
+| Name | Example | Required | Purpose |
+| --- | --- | --- | --- |
+| `SITE_PREFIX` | `/weppcloud` | Yes for prefixed route | Flask application root and generated URLs |
+| `WC1_DIR` | `/wc1` | Yes | Writable WEPPcloud run root |
+| `GEODATA_DIR` | `/geodata` | Yes | Read-only shared reference data root |
+| `POSTGRES_HOST` | `postgres-01.openwepp.arpa` | Yes | External PostgreSQL host |
+| `POSTGRES_PORT` | `5432` | Yes | External PostgreSQL port |
+| `POSTGRES_DB` | `wepppy` | Yes | Database name |
+| `POSTGRES_USER` | `wepppy` | Yes | Database role |
+| `REDIS_HOST` | `redis.weppcloud.svc.cluster.local` | Yes | Redis Service name |
+| `REDIS_PORT` | `6379` | Yes | Redis port |
+| `SESSION_REDIS_DB` | `11` | Recommended | Flask session database |
+| `ENABLE_LOCAL_LOGIN` | `false` | Canary choice | Disable user/password login until intentionally tested |
+| `GL_DASHBOARD_BATCH_ENABLED` | `false` | Canary choice | Avoid worker-dependent dashboard jobs |
+| `PYTHONUNBUFFERED` | `1` | Recommended | Immediate container logs |
+| `MPLCONFIGDIR` | `/tmp/matplotlib` | Recommended | Writable Matplotlib cache |
+
+Do not set `SQLALCHEMY_DATABASE_URI` or `DATABASE_URL` for this deployment.
+`wepppy.weppcloud.configuration` composes the URI from the non-secret PostgreSQL
+fields and `POSTGRES_PASSWORD_FILE`, preventing the password from appearing in
+an environment variable. Likewise, use host/port plus `REDIS_PASSWORD_FILE`
+instead of a credential-bearing Redis URL.
+
+## Minimum secret inventory
+
+The application secret loader prefers `<NAME>_FILE`, fails closed for an
+unreadable or empty configured file, and falls back to `<NAME>` only for
+backward compatibility. New deployments must mount files and expose only file
+paths in the environment.
+
+| Secret ID | File variable | Required for web canary | Notes |
+| --- | --- | --- | --- |
+| `flask_secret_key` | `SECRET_KEY_FILE` | Yes | Flask session signing; generate a canary value |
+| `flask_security_password_salt` | `SECURITY_PASSWORD_SALT_FILE` | Yes | Flask-Security hashing; generate a canary value |
+| `postgres_password` | `POSTGRES_PASSWORD_FILE` | Yes | Reuse the scoped `wepppy` database credential |
+| `redis_password` | `REDIS_PASSWORD_FILE` | Yes | Generate for the canary Redis instance |
+| `agent_jwt_secret` | `AGENT_JWT_SECRET_FILE` | Recommended | Keep agent tokens distinct from the Flask key even though code can fall back to it |
+
+No real Discord token is required for the web canary. A vendored module still
+opens `/workdir/weppcloud2/weppcloud2/discord_bot/.bot_token` during import.
+Mount an empty non-secret file at that path until the import-time coupling is
+removed. Never substitute a production Discord credential merely to satisfy
+startup.
+
+The following secrets are intentionally absent until their corresponding
+feature is enabled and tested: OAuth provider secrets, Zoho SMTP password, CAP
+secret, WEPP auth JWT set, MCP JWT secret, D-Tale token, administrator password,
+OpenTopography key, Climate Engine key, OpenET key, and `WC_TOKEN`. The complete
+cross-service inventory remains in [secrets.md](secrets.md).
+
+## Kubernetes example
+
+The example shows the interface, not deployable secret values. The real Secret
+must be SOPS-encrypted in Git, and the names must match the rendered manifests.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: weppcloud-web-runtime
+  namespace: weppcloud
+type: Opaque
+stringData:
+  flask_secret_key: REPLACE_THROUGH_SOPS
+  flask_security_password_salt: REPLACE_THROUGH_SOPS
+  postgres_password: REUSE_THROUGH_SOPS
+  redis_password: REPLACE_THROUGH_SOPS
+  agent_jwt_secret: REPLACE_THROUGH_SOPS
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: weppcloud-web
+  namespace: weppcloud
+spec:
+  template:
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: web
+          image: ghcr.io/rogerlew/wepppy@sha256:REPLACE_WITH_REVIEWED_DIGEST
+          args:
+            - gunicorn
+            - --workers
+            - "1"
+            - --threads
+            - "2"
+            - --timeout
+            - "120"
+            - --bind
+            - 0.0.0.0:8000
+            - --log-level
+            - info
+            - wepppy.weppcloud.app:app
+          env:
+            - {name: SITE_PREFIX, value: /weppcloud}
+            - {name: POSTGRES_HOST, value: postgres-01.openwepp.arpa}
+            - {name: POSTGRES_DB, value: wepppy}
+            - {name: POSTGRES_USER, value: wepppy}
+            - {name: REDIS_HOST, value: redis.weppcloud.svc.cluster.local}
+            - {name: SECRET_KEY_FILE, value: /run/secrets/weppcloud/flask_secret_key}
+            - {name: SECURITY_PASSWORD_SALT_FILE, value: /run/secrets/weppcloud/flask_security_password_salt}
+            - {name: POSTGRES_PASSWORD_FILE, value: /run/secrets/weppcloud/postgres_password}
+            - {name: REDIS_PASSWORD_FILE, value: /run/secrets/weppcloud/redis_password}
+            - {name: AGENT_JWT_SECRET_FILE, value: /run/secrets/weppcloud/agent_jwt_secret}
+          volumeMounts:
+            - name: runtime-secrets
+              mountPath: /run/secrets/weppcloud
+              readOnly: true
+      volumes:
+        - name: runtime-secrets
+          secret:
+            secretName: weppcloud-web-runtime
+            defaultMode: 0400
+```
+
+The final deployment must also mount `/wc1`, `/geodata`, and the empty Discord
+compatibility file; define startup/readiness/liveness probes; run as the image's
+non-root UID/GID; and apply resource limits and NetworkPolicies. Those concerns
+belong in the environment manifests, not in the secret object.
+
+## Startup acceptance checklist
+
+1. Pin the image by immutable digest and verify anonymous GHCR pull.
+2. Confirm each required secret file exists, is non-empty, and is not printed by
+   rendered YAML, process arguments, logs, or pod environment output.
+3. Confirm PostgreSQL is reachable only from the observed canary source and a
+   transaction can be rolled back.
+4. Confirm authenticated Redis connectivity and session DB isolation.
+5. Confirm `/wc1` is writable, `/geodata` is readable and not writable, and the
+   Discord compatibility path contains no credential.
+6. Confirm direct `/health` and the private prefixed route succeed.
+7. Confirm no RQ worker, Docker socket, public route, or production Compose
+   mutation is present.
+
+## Implementation references
+
+- `wepppy/weppcloud/configuration.py` — Flask, PostgreSQL, and session startup
+- `wepppy/config/secrets.py` — canonical `*_FILE` resolution behavior
+- `wepppy/config/redis_settings.py` — Redis URL construction and password injection
+- `docker/Dockerfile` and `docker/weppcloud-entrypoint.sh` — image startup
+- `docker/docker-compose.canary-smoke.yml` — isolated compatibility evidence
+- `docs/infrastructure/secrets.md` — full multi-service secret catalog

--- a/docs/work-packages/20260813_weppcloud_private_canary_image/artifacts/compatibility_inventory.md
+++ b/docs/work-packages/20260813_weppcloud_private_canary_image/artifacts/compatibility_inventory.md
@@ -25,6 +25,10 @@ The protected base file `docker/docker-compose.prod.yml` defines a broad product
 
 ## Secret and startup inventory
 
+The durable operator contract is now
+[`docs/infrastructure/weppcloud-web-runtime-contract.md`](../../../infrastructure/weppcloud-web-runtime-contract.md).
+This section records the compatibility investigation that led to it.
+
 The production base declares these secret IDs: `redis_password`, `discord_bot_token`, `postgres_password`, `flask_secret_key`, `flask_security_password_salt`, `wepp_auth_jwt_secrets`, `agent_jwt_secret`, `wepp_mcp_jwt_secret`, `dtale_internal_token`, `cap_secret`, `oauth_github_client_secret`, `oauth_google_client_secret`, `zoho_noreply_email_password`, `opentopography_api_key`, `climate_engine_api_key`, and `admin_password`.
 
 The minimum web process requires non-empty Flask `SECRET_KEY` and `SECURITY_PASSWORD_SALT`. The smoke contract also supplies a separate synthetic `AGENT_JWT_SECRET` and password-protected Redis. OAuth, SMTP, CAPTCHA/CAP, WEPP JWT, MCP JWT, D-Tale, admin, and external-data credentials are omitted.


### PR DESCRIPTION
## Summary

- establish the canonical WEPPcloud web startup and minimum secret contract
- provide sanitized Kubernetes configuration examples and startup acceptance checks
- link the contract from operator, Docker, and compatibility documentation
- explicitly preserve the existing production Compose deployments

## Validation

- `git diff --check`
- `tools/check_agents_size.sh AGENTS.md`
- secret-policy and manual credential-pattern checks passed in the infrastructure repository workflow

`wctl doc-lint` was unavailable on the iMac; repository CI remains authoritative for documentation checks.