### PR TITLE
Publish WEPPcloud auxiliary service images

### DIFF
--- a/.github/workflows/publish-weppcloud-aux-images.yml
+++ b/.github/workflows/publish-weppcloud-aux-images.yml
@@ -1,0 +1,109 @@
+name: Publish WEPPcloud auxiliary runtime images
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Build, test, and publish ${{ matrix.service }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - service: status
+            image: wepppy-status
+            dockerfile: services/status2/Dockerfile
+          - service: preflight
+            image: wepppy-preflight
+            dockerfile: services/preflight2/Dockerfile
+          - service: cap
+            image: wepppy-cap
+            dockerfile: services/cap/Dockerfile
+          - service: weppcloudr
+            image: weppcloudr
+            dockerfile: weppcloudR/Dockerfile
+    steps:
+      - name: Check out the dispatched source commit
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Derive immutable image coordinates
+        id: image
+        shell: bash
+        env:
+          PACKAGE_NAME: ${{ matrix.image }}
+        run: |
+          set -euo pipefail
+          image_name="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/${PACKAGE_NAME}"
+          image_tag="sha-${GITHUB_SHA}"
+          echo "name=${image_name}" >> "${GITHUB_OUTPUT}"
+          echo "tag=${image_tag}" >> "${GITHUB_OUTPUT}"
+          echo "ref=${image_name}:${image_tag}" >> "${GITHUB_OUTPUT}"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Build reviewed image into the runner
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64
+          load: true
+          tags: ${{ steps.image.outputs.ref }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+
+      - name: Validate runtime contract before publication
+        shell: bash
+        env:
+          SERVICE: ${{ matrix.service }}
+          IMAGE_REF: ${{ steps.image.outputs.ref }}
+        run: |
+          set -euo pipefail
+          docker/validate-aux-image-contract.sh "${SERVICE}" "${IMAGE_REF}" "${GITHUB_SHA}"
+
+      - name: Push tested image and capture digest
+        id: push
+        shell: bash
+        env:
+          IMAGE_REF: ${{ steps.image.outputs.ref }}
+        run: |
+          set -euo pipefail
+          docker push "${IMAGE_REF}" | tee push.log
+          digest=$(sed -n 's/^.*digest: \(sha256:[0-9a-f]\{64\}\).*$/\1/p' push.log | tail -1)
+          test -n "${digest}"
+          echo "digest=${digest}" >> "${GITHUB_OUTPUT}"
+
+      - name: Report immutable image digest
+        shell: bash
+        env:
+          SERVICE: ${{ matrix.service }}
+          IMAGE_NAME: ${{ steps.image.outputs.name }}
+          IMAGE_TAG: ${{ steps.image.outputs.tag }}
+          IMAGE_DIGEST: ${{ steps.push.outputs.digest }}
+          DOCKERFILE: ${{ matrix.dockerfile }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## ${SERVICE} runtime image"
+            echo
+            echo "- Source SHA: \`${GITHUB_SHA}\`"
+            echo "- Commit tag: \`${IMAGE_NAME}:${IMAGE_TAG}\`"
+            echo "- Immutable reference: \`${IMAGE_NAME}@${IMAGE_DIGEST}\`"
+            echo "- Dockerfile: \`${DOCKERFILE}\`"
+            echo "- Platform: \`linux/amd64\`"
+            echo "- Pre-publication runtime contract: \`PASS\`"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/docker/validate-aux-image-contract.sh
+++ b/docker/validate-aux-image-contract.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  echo "usage: $0 <status|preflight|cap|weppcloudr> <image> <expected-revision>" >&2
+  exit 2
+fi
+
+service=$1
+image=$2
+expected_revision=$3
+contract_id="wepppy-aux-contract-${service}-$$"
+network="${contract_id}-network"
+container="${contract_id}-service"
+redis_container="${contract_id}-redis"
+secret_dir=$(mktemp -d)
+
+cleanup() {
+  docker rm -f "${container}" "${redis_container}" >/dev/null 2>&1 || true
+  docker network rm "${network}" >/dev/null 2>&1 || true
+  rm -rf "${secret_dir}"
+}
+trap cleanup EXIT
+
+architecture=$(docker image inspect "${image}" --format '{{.Architecture}}')
+runtime_user=$(docker image inspect "${image}" --format '{{.Config.User}}')
+revision=$(docker image inspect "${image}" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}')
+
+[[ "${architecture}" == "amd64" ]]
+[[ -n "${runtime_user}" && "${runtime_user}" != "0" && "${runtime_user}" != "root" ]]
+[[ "${revision}" == "${expected_revision}" ]]
+
+wait_for_url() {
+  local url=$1
+  for _ in $(seq 1 60); do
+    if curl -fsS "${url}" >/dev/null; then
+      return 0
+    fi
+    sleep 1
+  done
+  docker logs "${container}" >&2 || true
+  return 1
+}
+
+case "${service}" in
+  status|preflight)
+    docker network create "${network}" >/dev/null
+    docker run -d --name "${redis_container}" --network "${network}" \
+      redis:8.2.1-alpine@sha256:f887e6dacdcfa8e14af2f625fdf4474ff8c37dc36ce13b9e89e6e9a901f155ad \
+      redis-server --requirepass contract-only >/dev/null
+    printf '%s' 'contract-only' > "${secret_dir}/redis_password"
+    chmod 0444 "${secret_dir}/redis_password"
+    if [[ "${service}" == "status" ]]; then
+      port=9002
+      prefix=STATUS
+      db=2
+    else
+      port=9001
+      prefix=PREFLIGHT
+      db=0
+    fi
+    docker run -d --name "${container}" --network "${network}" --read-only \
+      -p "127.0.0.1::${port}" \
+      -v "${secret_dir}/redis_password:/run/secrets/redis_password:ro" \
+      -e "${prefix}_REDIS_URL=redis://${redis_container}:6379/${db}" \
+      -e "${prefix}_REDIS_PASSWORD_FILE=/run/secrets/redis_password" \
+      -e "${prefix}_LISTEN_ADDR=0.0.0.0:${port}" \
+      "${image}" >/dev/null
+    host_port=$(docker port "${container}" "${port}/tcp" | awk -F: 'END {print $NF}')
+    wait_for_url "http://127.0.0.1:${host_port}/health"
+    ;;
+  cap)
+    docker run -d --name "${container}" --read-only \
+      --tmpfs /tmp:rw,noexec,nosuid,nodev \
+      --tmpfs /var/lib/cap:rw,nosuid,nodev \
+      -p 127.0.0.1::3000 \
+      -e CAP_SITE_KEY=contract-site \
+      -e CAP_SECRET=contract-only \
+      -e CAP_CORS_ORIGIN=https://canary.invalid \
+      "${image}" >/dev/null
+    host_port=$(docker port "${container}" 3000/tcp | awk -F: 'END {print $NF}')
+    wait_for_url "http://127.0.0.1:${host_port}/cap/health"
+    curl -fsS "http://127.0.0.1:${host_port}/cap/assets/widget.js" >/dev/null
+    ;;
+  weppcloudr)
+    docker run -d --name "${container}" --read-only \
+      --tmpfs /tmp:rw,nosuid,nodev \
+      --tmpfs /opt/weppcloudr/renv/cache:rw,nosuid,nodev \
+      -p 127.0.0.1::8050 \
+      -e PORT=8050 \
+      "${image}" >/dev/null
+    host_port=$(docker port "${container}" 8050/tcp | awk -F: 'END {print $NF}')
+    wait_for_url "http://127.0.0.1:${host_port}/healthz"
+    ;;
+  *)
+    echo "unsupported service: ${service}" >&2
+    exit 2
+    ;;
+esac
+
+echo "${service} image contract: PASS"

--- a/docker/validate-aux-image-contract.sh
+++ b/docker/validate-aux-image-contract.sh
@@ -77,6 +77,7 @@ case "${service}" in
       -e CAP_SITE_KEY=contract-site \
       -e CAP_SECRET=contract-only \
       -e CAP_CORS_ORIGIN=https://canary.invalid \
+      -e CAP_ASSET_ROOT=/opt/cap \
       "${image}" >/dev/null
     host_port=$(docker port "${container}" 3000/tcp | awk -F: 'END {print $NF}')
     wait_for_url "http://127.0.0.1:${host_port}/cap/health"

--- a/services/cap/Dockerfile
+++ b/services/cap/Dockerfile
@@ -1,13 +1,18 @@
 # syntax=docker/dockerfile:1
-FROM node:20-alpine
+ARG NODE_BASE_IMAGE=node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293
+FROM ${NODE_BASE_IMAGE}
 
 WORKDIR /app
 
 ARG CAP_REPO=https://github.com/tiagozip/cap
-ARG CAP_REF=main
+ARG CAP_REF=e069d5e8174527f997167d45a65eb724ed0a607d
 
 RUN apk add --no-cache git ca-certificates && \
-    git clone --depth=1 --branch "${CAP_REF}" "${CAP_REPO}" /opt/cap && \
+    git init /opt/cap && \
+    git -C /opt/cap remote add origin "${CAP_REPO}" && \
+    git -C /opt/cap fetch --depth=1 origin "${CAP_REF}" && \
+    git -C /opt/cap checkout --detach FETCH_HEAD && \
+    test "$(git -C /opt/cap rev-parse HEAD)" = "${CAP_REF}" && \
     rm -rf /opt/cap/.git
 
 COPY services/cap/package.json services/cap/package-lock.json ./
@@ -15,8 +20,14 @@ RUN npm ci --omit=dev
 
 COPY services/cap/server.js services/cap/config.js ./
 
+RUN addgroup -g 10001 -S cap && \
+    adduser -u 10001 -S -D -H -G cap cap && \
+    mkdir -p /var/lib/cap && \
+    chown -R cap:cap /app /var/lib/cap
+
 ENV NODE_ENV=production
 
 EXPOSE 3000
 
+USER 10001:10001
 CMD ["node", "server.js"]

--- a/services/preflight2/Dockerfile
+++ b/services/preflight2/Dockerfile
@@ -1,15 +1,17 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.25-alpine AS build
+ARG GO_BUILDER_IMAGE=golang:1.25-alpine@sha256:3eb6c2b3db8d55e38537302edb510b4417f8a115efbd5906d131ceba9468e29a
+ARG RUNTIME_IMAGE=gcr.io/distroless/static:nonroot@sha256:f7f8f729987ad0fdf6b05eeeae94b26e6a0f613bdf46feea7fc40f7bd72953e6
+
+FROM ${GO_BUILDER_IMAGE} AS build
 WORKDIR /src
 
 COPY services/preflight2/go.mod ./
 RUN go mod download
 COPY services/preflight2/ ./
-RUN go mod tidy
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o /preflight2 ./cmd/preflight2
 
-FROM gcr.io/distroless/static:nonroot
+FROM ${RUNTIME_IMAGE}
 COPY --from=build /preflight2 /preflight2
 EXPOSE 9001
 ENTRYPOINT ["/preflight2"]

--- a/services/status2/Dockerfile
+++ b/services/status2/Dockerfile
@@ -1,16 +1,18 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.25-alpine AS build
+ARG GO_BUILDER_IMAGE=golang:1.25-alpine@sha256:3eb6c2b3db8d55e38537302edb510b4417f8a115efbd5906d131ceba9468e29a
+ARG RUNTIME_IMAGE=gcr.io/distroless/static:nonroot@sha256:f7f8f729987ad0fdf6b05eeeae94b26e6a0f613bdf46feea7fc40f7bd72953e6
+
+FROM ${GO_BUILDER_IMAGE} AS build
 WORKDIR /src
 
 COPY services/status2/go.mod ./
 RUN go mod download
 
 COPY services/status2/ ./
-RUN go mod tidy
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o /status2 ./cmd/status2
 
-FROM gcr.io/distroless/static:nonroot
+FROM ${RUNTIME_IMAGE}
 COPY --from=build /status2 /status2
 EXPOSE 9002
 ENTRYPOINT ["/status2"]

--- a/weppcloudR/Dockerfile
+++ b/weppcloudR/Dockerfile
@@ -1,5 +1,10 @@
 FROM rocker/r-ver:4.3.2@sha256:4e32addfc4da3e660f6e0d05ce5e43d3eceb9db58a60b9a142e0dde9a654ead1
 
+ARG ARROW_APT_SOURCE_URL=https://apache.jfrog.io/artifactory/arrow/ubuntu/apache-arrow-apt-source-latest-jammy.deb
+ARG ARROW_APT_SOURCE_SHA256=9ef1afbcca1705ddd6f358672deb5ba4f858b248144ef6356d4b8f4788ac1fda
+ARG APP_UID=1000
+ARG APP_GID=993
+
 ENV RENV_CONFIG_CACHE_SYMLINKS=FALSE \
     RENVMGR_PATHS_CACHE=/opt/weppcloudr/renv/cache \
     RENV_PATHS_CACHE=/opt/weppcloudr/renv/cache \
@@ -18,7 +23,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gpg \
     lsb-release
 
-RUN curl -sS https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb -o /tmp/apache-arrow-apt-source.deb
+RUN curl -fsSL "${ARROW_APT_SOURCE_URL}" -o /tmp/apache-arrow-apt-source.deb && \
+    echo "${ARROW_APT_SOURCE_SHA256}  /tmp/apache-arrow-apt-source.deb" | sha256sum -c -
 
 RUN apt-get install -y /tmp/apache-arrow-apt-source.deb && \
     rm /tmp/apache-arrow-apt-source.deb
@@ -58,6 +64,12 @@ WORKDIR /srv/weppcloudr
 COPY weppcloudR/plumber.R weppcloudR/docker-entrypoint.R /srv/weppcloudr/
 COPY weppcloudR/templates /srv/weppcloudr/templates
 
+RUN groupadd --gid "${APP_GID}" weppcloudr && \
+    useradd --uid "${APP_UID}" --gid "${APP_GID}" --no-create-home --shell /usr/sbin/nologin weppcloudr && \
+    mkdir -p /opt/weppcloudr/renv/cache && \
+    chown -R "${APP_UID}:${APP_GID}" /srv/weppcloudr /opt/weppcloudr
+
 EXPOSE 80
 
+USER ${APP_UID}:${APP_GID}
 ENTRYPOINT ["Rscript", "/srv/weppcloudr/docker-entrypoint.R"]


### PR DESCRIPTION
## Summary

- pin base images and external CAP/Arrow build inputs
- run status, preflight, CAP, and WEPPcloudR as non-root images
- add runtime image-contract validation before GHCR publication
- add a manually dispatched, least-privilege publication workflow

## Validation

- status2 Go tests and runtime contract pass
- preflight2 Go tests and runtime contract pass
- CAP Node tests and runtime contract pass
- WEPPcloudR build and runtime contract pass
- production Compose renders successfully
- generated forest workflows remain current
- shell syntax and diff checks pass

The workflow is manual-only. Kubernetes deployment and the existing production Compose hosts are unchanged.