### PR TITLE
Support internal CAP verification URL

### DIFF
--- a/docs/infrastructure/secrets.md
+++ b/docs/infrastructure/secrets.md
@@ -99,6 +99,11 @@ This section is the Phase 0 “inventory” deliverable for the secrets migratio
   - `OPENET_API_KEY` authenticates requests to `openet-api.org` (OpenET monthly time-series API).
 - `CAP_SITE_KEY`:
   - Public “site key” used by browser clients. Do not store it as a secret file, but keep it adjacent to `CAP_SECRET` in deployment docs because operators often rotate them together.
+- `CAP_VERIFY_BASE_URL`:
+  - Optional non-secret server-only override for CAP verification. Keep
+    `CAP_BASE_URL=/cap` for browser assets while setting this to an internal
+    service URL such as `http://weppcloud-cap:3000/cap` in Kubernetes. Compose
+    behavior is unchanged when the override is absent.
 - `DATABASE_URL` / `SQLALCHEMY_DATABASE_URI`:
   - Treated as secret-bearing because they typically embed the DB password. Prefer composing them at runtime from non-secrets + `postgres_password` rather than storing them in env long-term.
 

--- a/tests/weppcloud/routes/test_cap_verify.py
+++ b/tests/weppcloud/routes/test_cap_verify.py
@@ -28,3 +28,20 @@ def test_cap_verify_marks_session_and_returns_success(monkeypatch: pytest.Monkey
 
         with client.session_transaction() as session:
             assert CAP_SESSION_KEY in session
+
+
+def test_cap_verify_uses_internal_verification_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = Flask(__name__)
+    monkeypatch.setenv("CAP_BASE_URL", "/cap")
+    monkeypatch.setenv("CAP_VERIFY_BASE_URL", "http://weppcloud-cap:3000/cap/")
+    monkeypatch.setenv("CAP_SITE_KEY", "canary-site")
+    monkeypatch.setenv("CAP_SECRET", "test-only-secret")
+
+    with app.test_request_context("https://weppcloud.example/weppcloud/login"):
+        assert cap_verify_module._resolve_cap_config() == (
+            "http://weppcloud-cap:3000/cap",
+            "canary-site",
+            "test-only-secret",
+        )

--- a/wepppy/weppcloud/utils/cap_verify.py
+++ b/wepppy/weppcloud/utils/cap_verify.py
@@ -17,6 +17,9 @@ class CapVerificationError(RuntimeError):
 
 def _resolve_cap_config() -> Tuple[str, str, str]:
     base_url = current_app.config.get("CAP_BASE_URL") or os.getenv("CAP_BASE_URL")
+    verify_base_url = current_app.config.get("CAP_VERIFY_BASE_URL") or os.getenv(
+        "CAP_VERIFY_BASE_URL"
+    )
     site_key = current_app.config.get("CAP_SITE_KEY") or os.getenv("CAP_SITE_KEY")
     secret = current_app.config.get("CAP_SECRET") or get_secret("CAP_SECRET")
 
@@ -27,7 +30,7 @@ def _resolve_cap_config() -> Tuple[str, str, str]:
     if not secret:
         raise CapVerificationError("CAP_SECRET is required for CAPTCHA verification.")
 
-    base_url = base_url.rstrip("/")
+    base_url = (verify_base_url or base_url).rstrip("/")
     if base_url.startswith("/"):
         if not has_request_context():
             raise CapVerificationError(


### PR DESCRIPTION
## What changed
- add optional `CAP_VERIFY_BASE_URL` for server-side CAPTCHA verification
- retain `CAP_BASE_URL` as the browser-facing asset/widget URL
- add focused regression coverage and deployment documentation

## Why
Kubernetes must keep browser CAP assets on public-relative `/cap` while server verification uses the internal CAP Service under default-deny egress. Without an override, verification hairpins through Tailscale.

## Compatibility
The override is optional. Existing production Docker Compose behavior is unchanged when it is absent.

## Validation
- focused deterministic test added
- clean diff check
- CI requested; local macOS checkout has no WEPPpy virtualenv
