### PR TITLE
Hydrate LFS assets in WEPPcloud runtime images

### DIFF
--- a/.github/workflows/publish-weppcloud-image.yml
+++ b/.github/workflows/publish-weppcloud-image.yml
@@ -20,6 +20,17 @@ jobs:
     steps:
       - name: Check out the dispatched source commit
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          lfs: true
+
+      - name: Materialize and verify every Git LFS asset
+        shell: bash
+        run: |
+          set -euo pipefail
+          git lfs install --local
+          git lfs pull --include="*" --exclude=""
+          git lfs checkout
+          python3 tools/verify_lfs_materialized.py --tracked
 
       - name: Derive immutable image coordinates
         id: image
@@ -55,7 +66,7 @@ jobs:
             STATIC_BUILDER_IMAGE=node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293
             RUNTIME_BASE_IMAGE=python:3.12-slim@sha256:229a2c5bfa27522db7815ea81f9bed70af17ccb9de9fc7ad142b1877b5830d36
             UV_INSTALLER_URL=https://astral.sh/uv/0.12.3/install.sh
-            ROSETTA_REF=471c6e9434cfc30035d591387ad933f842a27983
+            ROSETTA_REF=1c22335ee0e4055f45adb3e597e5bf49cd9a2c88
             WEPPCLOUD2_REF=7c92e33cd6c6b8d33732edd943f9840834d88b34
             F_ESRI_REF=fe3bac7b297a33d5aacc083c434bc5637a0d8604
             WBT_REF=314d15d68344890b43045e5325776a2841b0b1ca

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -121,6 +121,12 @@ RUN mkdir -p /workdir /opt/vendor /var/log/wepppy /var/lib/wepppy && \
 # Bring the application source into the image.
 COPY . /workdir/wepppy
 
+# The release checkout must contain real LFS objects, never pointer stubs. This
+# repeats the workflow gate inside the image build so local and alternate
+# builders fail closed as well.
+RUN python3 /workdir/wepppy/tools/verify_lfs_materialized.py \
+        --scan-root /workdir/wepppy
+
 # Copy pre-built static vendor assets generated in the Node stage.
 COPY --from=static-builder /app/dist/vendor/ /workdir/wepppy/wepppy/weppcloud/static/vendor/
 # Copy archive console bundle into static/js.
@@ -138,8 +144,9 @@ RUN set -euxo pipefail; \
             popd >/dev/null; \
         }; \
         pushd "${dest}" >/dev/null; \
-        git lfs pull || true; \
+        git lfs pull --include="*" --exclude=""; \
         popd >/dev/null; \
+        python3 /workdir/wepppy/tools/verify_lfs_materialized.py --scan-root "${dest}"; \
         rm -rf "${dest}/.git"; \
     }; \
     clone_repo "${WEPPCLOUD2_REF}" "${WEPPCLOUD2_REPO}" /opt/vendor/weppcloud2; \

--- a/docs/infrastructure/ui-rcds-nfs-vs-dev-nfs.md
+++ b/docs/infrastructure/ui-rcds-nfs-vs-dev-nfs.md
@@ -62,6 +62,29 @@ delete_benchmark_results
 - root=/tmp/delete-test files=3100 dirs=30 size_mb=12.11 create_s=0.461 delete_s=0.082 rewrite_s=4.847 sync_s=0.003
 ```
 
+### Home-lab `hpc-nfs` local ZFS backend
+
+The canonical benchmark was run directly on the home-lab NFS server (`hpc`,
+also referred to operationally as `hpc-nfs`) on 2026-08-21 UTC. The ZFS target
+was `/tank/kubernetes/benchmarks/delete-test-20260821T0233Z`; `/tmp` provided
+the same-host comparison. All flush options were enabled.
+
+```text
+delete_benchmark_results
+- root=/tank/kubernetes/benchmarks/delete-test-20260821T0233Z files=3100 dirs=30 size_mb=12.11 create_s=0.372 delete_s=0.075 rewrite_s=0.381 sync_s=0.013
+- root=/tmp/delete-test-20260821T0233Z files=3100 dirs=30 size_mb=12.11 create_s=0.230 delete_s=0.018 rewrite_s=0.238 sync_s=0.004
+```
+
+The server was effectively idle during the run. Its active NFS-facing
+interface was `eno1` at `10.20.0.40/24`, negotiated at `1000 Mb/s`; the two
+other server interfaces (`ens5f0` and `ens5f1`) were down with no carrier. Both
+benchmark trees were removed successfully after the run.
+
+This is a local ZFS-backend floor, not an NFS client benchmark: because the
+script ran on the server, these timings exclude the NFS protocol, client mount
+behavior, and 1 GbE network path. A cluster-client run against an exported
+path is required to characterize the end-to-end Kubernetes NFS experience.
+
 ## Comparison (baseline production / forest.local dev)
 
 Ratios (production time ÷ forest.local time):
@@ -90,9 +113,31 @@ Ratios (production time ÷ wepp2 time):
 
 ## Notes / Takeaways
 
-- This benchmark is dominated by metadata ops and stable-write latency (especially with `--fsync-files` / `--fsync-dirs`), not bandwidth; 10 GbE does not guarantee good small-file performance.
+- This benchmark is dominated by metadata ops and stable-write latency (especially with `--fsync-files` / `--fsync-dirs`), not bandwidth; a fast link does not guarantee good small-file performance.
 - Treat `sync_s` as a “system dirtiness / background IO” indicator, not a per-path metric.
 - For a heavier profile, bump `--files-per-dir` and/or `--dir-depth` (expect NFS to degrade faster than local FS).
+
+## Current RCDS WEPP1-to-NAS link (2026-08-20)
+
+The RCDS physical path between WEPP1 and the production NAS must now be treated
+as **1 GbE**, not 10 GbE. RCDS replaced the former 10 GbE switch in the recent
+past and the replacement left this NFS path at 1 GbE. Any earlier description
+of WEPP1 having a 10 GbE connection to the NAS is historical and no longer
+describes the effective physical topology.
+
+Checks from `wepp1` confirmed that:
+
+- `/geodata` is mounted from `nas.rocket.net:/wepp` using NFSv4.2;
+- `nas.rocket.net` resolved to `192.168.100.102` during the check; and
+- traffic to that address routes through `ens192` from `192.168.100.237`.
+
+The WEPP1 guest reports `ens192` as `10000 Mb/s`, but WEPP1 is a VMware virtual
+machine and that value is the virtual NIC link rate. It does not reveal the
+physical switch-port rate or prove 10 GbE end-to-end connectivity to the NAS.
+The guest observation is therefore compatible with, and must not override,
+the current 1 GbE physical-path inventory. A switch-side port inspection or a
+controlled end-to-end throughput test would be needed to independently measure
+the physical bottleneck from inside RCDS infrastructure.
 
 ## Production Incident: Stale NFS Handle During WEPP Watershed Close (2026-04-27)
 

--- a/docs/work-packages/20260813_weppcloud_private_canary_image/artifacts/compatibility_inventory.md
+++ b/docs/work-packages/20260813_weppcloud_private_canary_image/artifacts/compatibility_inventory.md
@@ -47,6 +47,32 @@ The GitHub workflow builds repository context `.` with `docker/Dockerfile` for `
 
 The publication run pinned the Dockerfile frontend, both base images, uv `0.12.3`, and all five sibling Git repositories. The exact inputs are recorded in `.github/workflows/publish-weppcloud-image.yml`. Debian package indexes and DuckDB's downloaded `spatial` extension remain externally resolved, so independently repeated builds are not guaranteed byte-identical. The published artifact itself is immutable at `ghcr.io/rogerlew/wepppy@sha256:ee92666229df8fdffe4b06b1dff2cfd0e9e06823ada59915c8b492d8a468eb51`.
 
+### Git LFS hydration correction (2026-08-20)
+
+The original publication workflow checked out source without hydrating Git LFS.
+The resulting image copied pointer stubs into the runtime tree. In particular,
+`wepppy/climates/cligen/2015_stations.db` was a 131-byte pointer rather than the
+356,352-byte SQLite catalog. WEPPpy consequently entered its development
+fallback and selected `tests/neverland_.par` (Lewiston) for a Lake Tahoe run.
+The original digest is therefore invalid for climate-station selection and must
+not be promoted further.
+
+The corrected publication contract is fail-closed at two boundaries:
+
+1. GitHub Actions explicitly enables Git LFS, runs `git lfs install --local`,
+   pulls and checks out every tracked object, and verifies every path reported
+   by `git lfs ls-files` before invoking BuildKit.
+2. `docker/Dockerfile` scans the copied repository tree for pointer headers and
+   fails the build if any remain. Vendored sibling repositories now use a hard
+   `git lfs pull` and receive the same copied-tree scan; LFS download failure is
+   no longer ignored.
+
+At correction time the repository inventory contained 639 LFS objects totaling
+approximately 1.26 GB. A complete local hydration and checkout succeeded, all
+639 tracked paths passed verification, and the hydrated Cligen catalog opened
+as SQLite with 2,765 station rows. A new immutable digest still must be
+published and deployed before climate integration testing resumes.
+
 GitHub Actions run `31739217249` built source `ed1b538df02a8db0d709257ea9dacc330c56b9d9`, pushed tag `ghcr.io/rogerlew/wepppy:sha-ed1b538df02a8db0d709257ea9dacc330c56b9d9`, and reported digest `sha256:ee92666229df8fdffe4b06b1dff2cfd0e9e06823ada59915c8b492d8a468eb51`. An authenticated digest pull succeeded. An unauthenticated manifest request returned HTTP 401, demonstrating that the package was not publicly readable without changing repository or package settings.
 
 ## Protected-file non-mutation evidence

--- a/docs/work-packages/20260813_weppcloud_private_canary_image/package.md
+++ b/docs/work-packages/20260813_weppcloud_private_canary_image/package.md
@@ -45,6 +45,9 @@ This package delivers the non-live WEPPpy half of the private WEPPcloud canary: 
 - [x] Existing production Compose files are byte-for-byte unchanged.
 - [x] Lint/tests and a secret-sensitive diff review pass.
 - [x] A ready-for-review PR records the source SHA, image tag/digest, validation, and blockers.
+- [ ] A replacement common-runtime image is built only after all tracked Git
+  LFS objects are materialized and the copied image tree passes the pointer
+  scan added after the 2026-08-20 climate-station incident.
 
 ## Parameterization ADR Gate
 
@@ -100,3 +103,7 @@ This package delivers the non-live WEPPpy half of the private WEPPcloud canary: 
 ## Follow-up Work
 
 - Kubernetes manifests, live apply, production promotion, and worker compatibility remain separately governed and unauthorized here.
+- The originally published digest contains Git LFS pointer stubs, including the
+  Cligen station catalog. It must not be promoted further. Publish and validate
+  a replacement digest using the fail-closed LFS gates before resuming climate
+  integration testing.

--- a/tests/tools/test_verify_lfs_materialized.py
+++ b/tests/tools/test_verify_lfs_materialized.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+import pytest
+
+from tools.verify_lfs_materialized import LFS_POINTER_HEADER, is_lfs_pointer, verify
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_pointer_header_is_detected(tmp_path: Path) -> None:
+    pointer = tmp_path / "asset.db"
+    pointer.write_bytes(LFS_POINTER_HEADER + b"oid sha256:abc\nsize 42\n")
+
+    assert is_lfs_pointer(pointer)
+    assert verify([pointer]) == (1, [pointer])
+
+
+def test_materialized_binary_is_accepted(tmp_path: Path) -> None:
+    asset = tmp_path / "asset.db"
+    asset.write_bytes(b"SQLite format 3\x00" + b"\x00" * 64)
+
+    assert not is_lfs_pointer(asset)
+    assert verify([asset]) == (1, [])
+
+
+def test_missing_tracked_file_is_rejected(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.bin"
+
+    assert verify([missing]) == (1, [missing])

--- a/tools/verify_lfs_materialized.py
+++ b/tools/verify_lfs_materialized.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Fail when Git LFS pointer files remain in a checkout or build tree."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import subprocess
+import sys
+from typing import Iterable
+
+
+LFS_POINTER_HEADER = b"version https://git-lfs.github.com/spec/v1\n"
+
+
+def is_lfs_pointer(path: Path) -> bool:
+    """Return whether *path* begins with the canonical Git LFS pointer header."""
+    try:
+        with path.open("rb") as stream:
+            return stream.read(len(LFS_POINTER_HEADER)) == LFS_POINTER_HEADER
+    except (OSError, PermissionError):
+        return False
+
+
+def tracked_lfs_paths(repository: Path) -> list[Path]:
+    """Return paths tracked by Git LFS at the repository's current revision."""
+    result = subprocess.run(
+        ["git", "lfs", "ls-files", "--name-only"],
+        cwd=repository,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [repository / line for line in result.stdout.splitlines() if line]
+
+
+def scanned_paths(root: Path, excluded_names: set[str]) -> Iterable[Path]:
+    """Yield regular files below *root*, pruning excluded directory names."""
+    for directory, directory_names, file_names in os.walk(root):
+        directory_names[:] = [name for name in directory_names if name not in excluded_names]
+        base = Path(directory)
+        for name in file_names:
+            path = base / name
+            if path.is_file() and not path.is_symlink():
+                yield path
+
+
+def verify(paths: Iterable[Path]) -> tuple[int, list[Path]]:
+    """Return the number checked and any paths that remain LFS pointers."""
+    checked = 0
+    pointers: list[Path] = []
+    for path in paths:
+        checked += 1
+        if not path.is_file():
+            pointers.append(path)
+        elif is_lfs_pointer(path):
+            pointers.append(path)
+    return checked, pointers
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
+        "--tracked",
+        action="store_true",
+        help="verify every path reported by git lfs ls-files",
+    )
+    mode.add_argument(
+        "--scan-root",
+        type=Path,
+        help="scan a copied source or image tree without requiring Git metadata",
+    )
+    parser.add_argument(
+        "--repository",
+        type=Path,
+        default=Path.cwd(),
+        help="repository used by --tracked (default: current directory)",
+    )
+    parser.add_argument(
+        "--exclude-name",
+        action="append",
+        default=[".git"],
+        help="directory name pruned by --scan-root (repeatable; default: .git)",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repository = args.repository.resolve()
+    if args.tracked:
+        paths = tracked_lfs_paths(repository)
+        display_root = repository
+        mode = "tracked Git LFS files"
+    else:
+        display_root = args.scan_root.resolve()
+        paths = scanned_paths(display_root, set(args.exclude_name))
+        mode = "files in copied tree"
+
+    checked, pointers = verify(paths)
+    if pointers:
+        print(
+            f"ERROR: {len(pointers)} unmaterialized or missing Git LFS file(s) "
+            f"found among {checked} {mode}:",
+            file=sys.stderr,
+        )
+        for path in pointers:
+            try:
+                rendered = path.relative_to(display_root)
+            except ValueError:
+                rendered = path
+            print(f"- {rendered}", file=sys.stderr)
+        return 1
+
+    print(f"Git LFS verification passed: {checked} {mode} are materialized.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- hydrate and verify all tracked Git LFS objects before the common runtime build
- fail Docker builds when repository or vendored trees contain pointer stubs
- pin Rosetta to the reviewed streaming implementation
- record the invalid Cligen fallback incident and NFS benchmark evidence

## Validation
- 639/639 tracked LFS objects materialized (about 1.26 GB)
- copied-tree scan passed across 50,935 files
- hydrated Cligen SQLite catalog contains 2,765 stations
- verifier behavior checks passed
- workflow YAML parsed
- documentation lint passed with 0 errors and 0 warnings
- git diff --check passed

## Deployment
After merge, publish the immutable common runtime image, update the open-wepp-org GitOps digest, and validate station selection in the private canary.