### PR TITLE
Avoid fsGroup mutation on WEPPcloudR NFS mounts

### DIFF
--- a/tests/rq/test_weppcloudr_control_plane.py
+++ b/tests/rq/test_weppcloudr_control_plane.py
@@ -243,6 +243,12 @@ def test_job_spec_is_fixed_hardened_and_run_wd_scoped() -> None:
     assert job["backoffLimit"] == 0
     assert "ttlSecondsAfterFinished" not in job
     assert pod["automountServiceAccountToken"] is False
+    assert pod["securityContext"] == {
+        "runAsNonRoot": True,
+        "runAsUser": 1000,
+        "runAsGroup": 993,
+    }
+    assert "fsGroup" not in pod["securityContext"]
     assert container["image"] == f"ghcr.io/open-wepp/weppcloudr@{IMAGE}"
     assert container["workingDir"] == request.run_root
     assert container["securityContext"] == {

--- a/wepppy/rq/weppcloudr_control_plane.py
+++ b/wepppy/rq/weppcloudr_control_plane.py
@@ -312,7 +312,15 @@ def build_job_spec(
         "automountServiceAccountToken": False,
         "serviceAccountName": config.service_account,
         "restartPolicy": "Never",
-        "securityContext": {"runAsNonRoot": True, "fsGroup": 993},
+        # The retained NFS exports are root-squashed.  A pod-level fsGroup asks
+        # kubelet to recursively mutate the mounted run tree and fails before
+        # the renderer starts.  Match the established WEPPcloud workload
+        # identity directly instead.
+        "securityContext": {
+            "runAsNonRoot": True,
+            "runAsUser": 1000,
+            "runAsGroup": 993,
+        },
         "containers": [
             {
                 "name": "renderer",


### PR DESCRIPTION
Renderer Jobs now run directly as the established WEPPcloud UID/GID 1000:993 without pod fsGroup. This prevents kubelet recursive ownership mutation on the root-squashed /wc1 export. Adds an exact Job-spec regression assertion.