### PR TITLE
Avoid NFS subPath mounts for WEPPcloudR jobs

### DIFF
--- a/tests/rq/test_weppcloudr_control_plane.py
+++ b/tests/rq/test_weppcloudr_control_plane.py
@@ -225,7 +225,7 @@ def _controller(maximum: int = 2, now: list[float] | None = None):
     )
 
 
-def test_job_spec_is_fixed_hardened_and_run_wd_scoped() -> None:
+def test_job_spec_is_fixed_hardened_and_uses_root_squash_safe_mount() -> None:
     request = _request()
 
     spec, digest = build_job_spec(
@@ -251,6 +251,7 @@ def test_job_spec_is_fixed_hardened_and_run_wd_scoped() -> None:
     assert "fsGroup" not in pod["securityContext"]
     assert container["image"] == f"ghcr.io/open-wepp/weppcloudr@{IMAGE}"
     assert container["workingDir"] == request.run_root
+    assert container["args"][0] == "/wc1/.weppcloudr/requests/job-1.json"
     assert container["securityContext"] == {
         "allowPrivilegeEscalation": False,
         "readOnlyRootFilesystem": True,
@@ -258,6 +259,13 @@ def test_job_spec_is_fixed_hardened_and_run_wd_scoped() -> None:
         "seccompProfile": {"type": "RuntimeDefault"},
     }
     assert container["args"][-1] == "3"
+    assert container["volumeMounts"][0] == {
+        "name": "run",
+        "mountPath": "/wc1",
+    }
+    assert all("subPath" not in mount for mount in container["volumeMounts"])
+    assert [volume["name"] for volume in pod["volumes"]].count("run") == 1
+    assert "request" not in [volume["name"] for volume in pod["volumes"]]
     assert len(digest) == 64
 
 
@@ -310,7 +318,7 @@ def test_job_spec_rejects_unapproved_or_escaping_run_paths(
         )
 
 
-def test_job_spec_uses_explicit_pvc_mapping() -> None:
+def test_job_spec_validates_explicit_pvc_mapping_without_kubelet_subpaths() -> None:
     request = _request()
     spec, _digest = build_job_spec(
         request,
@@ -321,8 +329,9 @@ def test_job_spec_uses_explicit_pvc_mapping() -> None:
         request_subpath=".weppcloudr/requests/request.json",
     )
 
-    run_mount = spec["spec"]["template"]["spec"]["containers"][0]["volumeMounts"][0]
-    assert run_mount["subPath"] == "runs/ru/run-1"
+    container = spec["spec"]["template"]["spec"]["containers"][0]
+    assert container["workingDir"] == "/wc1/runs/ru/run-1"
+    assert container["volumeMounts"][0] == {"name": "run", "mountPath": "/wc1"}
 
 
 def test_submit_creates_once_binds_uid_and_reuses_receipt() -> None:

--- a/wepppy/rq/weppcloudr_control_plane.py
+++ b/wepppy/rq/weppcloudr_control_plane.py
@@ -296,6 +296,14 @@ def build_job_spec(
         raise KubernetesRenderError(
             "weppcloudr_k8s_admission_rejected", "invalid request PVC subPath"
         )
+    # Preserve the allowlisted run-root admission check even though the NFS
+    # volume is mounted without a Kubernetes subPath. Talos kubelet runs
+    # subPath preparation as root; root_squash maps that identity to nobody and
+    # rejects protected WEPPcloud directory traversal before the container can
+    # start. The short-lived, immutable renderer therefore receives the same
+    # /wc1 volume boundary as existing WEPPcloud workers and remains confined
+    # by its fixed request, tokenless identity, and no-egress policy.
+    _pvc_subpath(request, config)
     labels = {
         "app.kubernetes.io/name": "weppcloudr-render",
         "weppcloud.org/rq-id-hash": hashlib.sha256(
@@ -328,7 +336,7 @@ def build_job_spec(
                 "imagePullPolicy": "IfNotPresent",
                 "command": ["Rscript", "/srv/weppcloudr/render-request-v1.R"],
                 "args": [
-                    "/run/weppcloudr/request.json",
+                    f"/wc1/{request_subpath}",
                     request_digest,
                     str(fencing_generation),
                 ],
@@ -349,14 +357,7 @@ def build_job_spec(
                 "volumeMounts": [
                     {
                         "name": "run",
-                        "mountPath": request.run_root,
-                        "subPath": _pvc_subpath(request, config),
-                    },
-                    {
-                        "name": "request",
-                        "mountPath": "/run/weppcloudr/request.json",
-                        "subPath": request_subpath,
-                        "readOnly": True,
+                        "mountPath": "/wc1",
                     },
                     {"name": "geodata", "mountPath": "/geodata", "readOnly": True},
                     {"name": "tmp", "mountPath": "/tmp"},
@@ -365,7 +366,6 @@ def build_job_spec(
         ],
         "volumes": [
             {"name": "run", "persistentVolumeClaim": {"claimName": config.run_pvc}},
-            {"name": "request", "persistentVolumeClaim": {"claimName": config.run_pvc}},
             {
                 "name": "geodata",
                 "persistentVolumeClaim": {"claimName": config.geodata_pvc, "readOnly": True},


### PR DESCRIPTION
## Summary
- keep allowlisted run-root and request-path validation
- mount the retained root-squashed /wc1 PVC without Kubernetes subPath
- reference the immutable request through its validated path
- preserve tokenless, non-root, fixed-command, no-egress renderer controls

## Why
Talos kubelet performs secure subPath preparation as root. NFS root_squash maps that identity to nobody, so protected WEPPcloud directories fail before container start. Weakening root_squash is not acceptable.

## Validation
- focused control-plane and adapter suites on Linux: 28 passed
- explicit regression checks reject subPath mounts and duplicate request volumes