### PR TITLE
Start WEPPcloudR jobs outside root-squashed NFS

### DIFF
--- a/tests/rq/test_weppcloudr_control_plane.py
+++ b/tests/rq/test_weppcloudr_control_plane.py
@@ -250,7 +250,7 @@ def test_job_spec_is_fixed_hardened_and_uses_root_squash_safe_mount() -> None:
     }
     assert "fsGroup" not in pod["securityContext"]
     assert container["image"] == f"ghcr.io/open-wepp/weppcloudr@{IMAGE}"
-    assert container["workingDir"] == request.run_root
+    assert container["workingDir"] == "/tmp"
     assert container["args"][0] == "/wc1/.weppcloudr/requests/job-1.json"
     assert container["securityContext"] == {
         "allowPrivilegeEscalation": False,
@@ -330,7 +330,7 @@ def test_job_spec_validates_explicit_pvc_mapping_without_kubelet_subpaths() -> N
     )
 
     container = spec["spec"]["template"]["spec"]["containers"][0]
-    assert container["workingDir"] == "/wc1/runs/ru/run-1"
+    assert container["workingDir"] == "/tmp"
     assert container["volumeMounts"][0] == {"name": "run", "mountPath": "/wc1"}
 
 

--- a/wepppy/rq/weppcloudr_control_plane.py
+++ b/wepppy/rq/weppcloudr_control_plane.py
@@ -340,7 +340,11 @@ def build_job_spec(
                     request_digest,
                     str(fencing_generation),
                 ],
-                "workingDir": request.run_root,
+                # OCI runtime prepares workingDir before switching to the
+                # application UID. A protected root-squashed NFS path therefore
+                # fails during container init even though UID 1000 can access it.
+                # The renderer consumes absolute paths from the signed request.
+                "workingDir": "/tmp",
                 "securityContext": {
                     "allowPrivilegeEscalation": False,
                     "readOnlyRootFilesystem": True,


### PR DESCRIPTION
## Summary
- start renderer containers in writable /tmp rather than an NFS working directory
- continue consuming absolute run/request paths from the validated request
- preserve the no-subPath, root-squash-compatible mount contract

## Why
OCI runtime prepares workingDir before switching to UID 1000. On root-squashed NFS that pre-start root traversal is rejected even though the application UID can access the run.

## Validation
Focused Linux controller and adapter suites: 28 passed.