### PR TITLE
Enter WEPPcloudR run root after container start

### DIFF
--- a/tests/rq/test_weppcloudr_control_plane.py
+++ b/tests/rq/test_weppcloudr_control_plane.py
@@ -251,7 +251,18 @@ def test_job_spec_is_fixed_hardened_and_uses_root_squash_safe_mount() -> None:
     assert "fsGroup" not in pod["securityContext"]
     assert container["image"] == f"ghcr.io/open-wepp/weppcloudr@{IMAGE}"
     assert container["workingDir"] == "/tmp"
-    assert container["args"][0] == "/run/weppcloudr/request.json"
+    assert container["command"] == ["/bin/sh", "-c"]
+    assert container["args"] == [
+        (
+            'cd -- "$1" && exec Rscript '
+            '/srv/weppcloudr/render-request-v1.R "$2" "$3" "$4"'
+        ),
+        "weppcloudr-entrypoint",
+        request.run_root,
+        "/run/weppcloudr/request.json",
+        request.digest,
+        "3",
+    ]
     assert container["securityContext"] == {
         "allowPrivilegeEscalation": False,
         "readOnlyRootFilesystem": True,

--- a/wepppy/rq/weppcloudr_control_plane.py
+++ b/wepppy/rq/weppcloudr_control_plane.py
@@ -363,8 +363,14 @@ def build_job_spec(
                 "name": "renderer",
                 "image": renderer_image,
                 "imagePullPolicy": "IfNotPresent",
-                "command": ["Rscript", "/srv/weppcloudr/render-request-v1.R"],
+                "command": ["/bin/sh", "-c"],
                 "args": [
+                    (
+                        'cd -- "$1" && exec Rscript '
+                        '/srv/weppcloudr/render-request-v1.R "$2" "$3" "$4"'
+                    ),
+                    "weppcloudr-entrypoint",
+                    request.run_root,
                     "/run/weppcloudr/request.json",
                     request_digest,
                     str(fencing_generation),


### PR DESCRIPTION
## Summary
- start in pod-local /tmp so OCI avoids root-squashed NFS traversal
- cd to the signed run root after UID 1000 is active
- pass every value as a positional shell argument, with no interpolation
- exec the fixed renderer against canonical staged request

## Validation
Focused Linux controller and adapter suites: 28 passed.