### PR TITLE
Set WEPPcloudR production template contract

### DIFF
--- a/tests/rq/test_weppcloudr_control_plane.py
+++ b/tests/rq/test_weppcloudr_control_plane.py
@@ -251,6 +251,16 @@ def test_job_spec_is_fixed_hardened_and_uses_root_squash_safe_mount() -> None:
     assert "fsGroup" not in pod["securityContext"]
     assert container["image"] == f"ghcr.io/open-wepp/weppcloudr@{IMAGE}"
     assert container["workingDir"] == "/tmp"
+    assert container["env"] == [
+        {
+            "name": "TEMPLATE_ROOT",
+            "value": "/srv/weppcloudr/templates/scripts/users/chinmay",
+        },
+        {
+            "name": "DEVAL_TEMPLATE",
+            "value": "/srv/weppcloudr/templates/scripts/users/chinmay/new_report.Rmd",
+        },
+    ]
     assert container["command"] == ["/bin/sh", "-c"]
     assert container["args"] == [
         (

--- a/wepppy/rq/weppcloudr_control_plane.py
+++ b/wepppy/rq/weppcloudr_control_plane.py
@@ -380,6 +380,19 @@ def build_job_spec(
                 # fails during container init even though UID 1000 can access it.
                 # The renderer consumes absolute paths from the signed request.
                 "workingDir": "/tmp",
+                "env": [
+                    {
+                        "name": "TEMPLATE_ROOT",
+                        "value": "/srv/weppcloudr/templates/scripts/users/chinmay",
+                    },
+                    {
+                        "name": "DEVAL_TEMPLATE",
+                        "value": (
+                            "/srv/weppcloudr/templates/scripts/users/chinmay/"
+                            "new_report.Rmd"
+                        ),
+                    },
+                ],
                 "securityContext": hardened_container_security,
                 "resources": {
                     "requests": {


### PR DESCRIPTION
## Summary
- set the same TEMPLATE_ROOT and DEVAL_TEMPLATE paths used by production Compose
- point at the templates already included in the immutable renderer image
- assert the exact fixed environment in generated Job tests

## Validation
Focused Linux controller and adapter suites: 28 passed.