### PR TITLE
Keep WEPPcloudR knit intermediates on writable tmpfs

### DIFF
--- a/weppcloudR/plumber.R
+++ b/weppcloudR/plumber.R
@@ -285,6 +285,10 @@ render_deval <- function(run_path, runid, config = NULL, skip_cache = FALSE, par
         params = params,
         output_file = render_target,
         output_dir = dirname(render_target),
+        # The production image has a read-only root filesystem. Keep all knit
+        # intermediates in the pod-local writable tmpfs; only the fenced final
+        # artifact is published to the run directory.
+        intermediates_dir = tempdir(),
         envir = new.env(parent = globalenv())
       )
       if (publish_after_render && !file.rename(render_target, output_file)) {


### PR DESCRIPTION
## Summary
- direct rmarkdown knit intermediates to R's pod-local tempdir
- preserve read-only renderer root filesystem
- keep only the fenced final artifact on NFS

## Validation
The complete modified R source parses successfully inside the deployed renderer runtime.