### PR TITLE
Vendor Font Awesome for offline WEPPcloudR reports

### DIFF
--- a/docker/validate-aux-image-contract.sh
+++ b/docker/validate-aux-image-contract.sh
@@ -84,6 +84,12 @@ case "${service}" in
     curl -fsS "http://127.0.0.1:${host_port}/cap/assets/widget.js" >/dev/null
     ;;
   weppcloudr)
+    fontawesome_digest=$(
+      docker run --rm --network none --entrypoint sha256sum "${image}" \
+        /srv/weppcloudr/vendor/fontawesome/5.3.1/all.js \
+        | awk '{print $1}'
+    )
+    [[ "${fontawesome_digest}" == "8cb270b4d9485a93b31df98113fda8723ffc067fa7bfa90cedd47b76f7b10be1" ]]
     docker run -d --name "${container}" --read-only \
       --tmpfs /tmp:rw,nosuid,nodev \
       --tmpfs /opt/weppcloudr/renv/cache:rw,nosuid,nodev \

--- a/docs/schemas/weppcloudr-render-execution-contract.md
+++ b/docs/schemas/weppcloudr-render-execution-contract.md
@@ -373,6 +373,11 @@ until bounded reconnect/reconciliation fails.
   NetworkPolicies. Only documented storage traffic needed by the PVC provider
   MAY be allowed. Kubernetes API, cloud metadata, unrelated cluster services,
   and external egress MUST remain denied.
+- Report templates and renderer dependencies MUST NOT fetch JavaScript, CSS,
+  fonts, or other presentation assets at runtime. Required assets MUST be
+  versioned and checksum-pinned into the immutable renderer image, retain their
+  applicable license notices, and be embedded into the self-contained report
+  from that local copy.
 - Routine rendering MUST NOT use Kubernetes `pods/exec`. Pod exec grants
   arbitrary command execution, bypasses per-render scheduling and resource
   accounting, and cannot be restricted by standard RBAC to the approved R

--- a/tests/rq/test_weppcloudr_backends.py
+++ b/tests/rq/test_weppcloudr_backends.py
@@ -332,6 +332,23 @@ def test_one_shot_renderer_has_strict_fixed_request_contract() -> None:
     assert "Sys.readlink(final_output) !=" not in source
 
 
+def test_weppcloudr_uses_checksum_pinned_local_fontawesome() -> None:
+    dockerfile = (REPO_ROOT / "weppcloudR/Dockerfile").read_text(encoding="utf-8")
+    renderer = (REPO_ROOT / "weppcloudR/plumber.R").read_text(encoding="utf-8")
+    templates = list((REPO_ROOT / "weppcloudR/templates").rglob("*.Rmd"))
+
+    expected = "8cb270b4d9485a93b31df98113fda8723ffc067fa7bfa90cedd47b76f7b10be1"
+    assert expected in dockerfile
+    assert expected in renderer
+    assert "/srv/weppcloudr/vendor/fontawesome/5.3.1/all.js" in renderer
+    assert "use_fontawesome = FALSE" in renderer
+    assert "local_fontawesome_header" in renderer
+    assert all(
+        "use_fontawesome: true" not in path.read_text(encoding="utf-8")
+        for path in templates
+    )
+
+
 def test_fenced_publisher_preserves_foreign_staging_file_and_retry_succeeds(
     tmp_path: Path,
 ) -> None:

--- a/weppcloudR/Dockerfile
+++ b/weppcloudR/Dockerfile
@@ -2,6 +2,8 @@ FROM rocker/r-ver:4.3.2@sha256:4e32addfc4da3e660f6e0d05ce5e43d3eceb9db58a60b9a14
 
 ARG ARROW_APT_SOURCE_URL=https://apache.jfrog.io/artifactory/arrow/ubuntu/apache-arrow-apt-source-latest-jammy.deb
 ARG ARROW_APT_SOURCE_SHA256=9ef1afbcca1705ddd6f358672deb5ba4f858b248144ef6356d4b8f4788ac1fda
+ARG FONTAWESOME_URL=https://use.fontawesome.com/releases/v5.3.1/js/all.js
+ARG FONTAWESOME_SHA256=8cb270b4d9485a93b31df98113fda8723ffc067fa7bfa90cedd47b76f7b10be1
 ARG APP_UID=1000
 ARG APP_GID=993
 
@@ -61,6 +63,15 @@ RUN R -q -e "options(repos = c(CRAN = Sys.getenv('RSPM'))); install.packages(c( 
         ))"
 
 WORKDIR /srv/weppcloudr
+
+# Vendor the exact Font Awesome Free asset used by cleanrmd. The upstream file
+# retains its MIT/CC BY 4.0/SIL OFL 1.1 license notice. Runtime rendering must
+# consume this verified image-local copy and never fetch it from the internet.
+RUN mkdir -p /srv/weppcloudr/vendor/fontawesome/5.3.1 && \
+    curl -fsSL "${FONTAWESOME_URL}" \
+      -o /srv/weppcloudr/vendor/fontawesome/5.3.1/all.js && \
+    echo "${FONTAWESOME_SHA256}  /srv/weppcloudr/vendor/fontawesome/5.3.1/all.js" \
+      | sha256sum -c -
 
 COPY weppcloudR/plumber.R weppcloudR/docker-entrypoint.R weppcloudR/render-compose-request.R weppcloudR/render-request-v1.R weppcloudR/publish_fenced.py /srv/weppcloudr/
 RUN chmod 0555 /srv/weppcloudr/publish_fenced.py

--- a/weppcloudR/plumber.R
+++ b/weppcloudR/plumber.R
@@ -17,6 +17,41 @@ PROFILE_PLAYBACK_FORK_ROOT <- Sys.getenv("PROFILE_PLAYBACK_FORK_ROOT", file.path
 PROFILE_PLAYBACK_ARCHIVE_ROOT <- Sys.getenv("PROFILE_PLAYBACK_ARCHIVE_ROOT", file.path(PROFILE_PLAYBACK_BASE, "archive"))
 TEMPLATE_ROOT <- Sys.getenv("TEMPLATE_ROOT", "/srv/weppcloudr/templates")
 DEFAULT_TEMPLATE <- Sys.getenv("DEVAL_TEMPLATE", file.path(TEMPLATE_ROOT, "new_report.Rmd"))
+FONTAWESOME_JS <- Sys.getenv(
+  "FONTAWESOME_JS",
+  "/srv/weppcloudr/vendor/fontawesome/5.3.1/all.js"
+)
+FONTAWESOME_SHA256 <- "8cb270b4d9485a93b31df98113fda8723ffc067fa7bfa90cedd47b76f7b10be1"
+
+fontawesome_header <- function() {
+  if (!file.exists(FONTAWESOME_JS) || file.info(FONTAWESOME_JS)$isdir) {
+    stop("vendored Font Awesome asset is unavailable")
+  }
+  link_target <- Sys.readlink(FONTAWESOME_JS)
+  if (!is.na(link_target) && nzchar(link_target)) {
+    stop("vendored Font Awesome asset must not be a symlink")
+  }
+  digest_output <- system2(
+    "sha256sum",
+    shQuote(FONTAWESOME_JS),
+    stdout = TRUE,
+    stderr = TRUE
+  )
+  if (!is.null(attr(digest_output, "status")) && attr(digest_output, "status") != 0L) {
+    stop("could not verify vendored Font Awesome asset")
+  }
+  digest <- strsplit(digest_output[[1L]], "[[:space:]]+")[[1L]][[1L]]
+  if (!identical(digest, FONTAWESOME_SHA256)) {
+    stop("vendored Font Awesome asset checksum mismatch")
+  }
+  header <- tempfile(pattern = "fontawesome-5.3.1-", fileext = ".html")
+  writeLines(
+    c("<script>", readLines(FONTAWESOME_JS, warn = FALSE), "</script>"),
+    header,
+    useBytes = TRUE
+  )
+  header
+}
 
 resolve_batch_run_root <- function(batch_name, runid) {
   batch_dir <- file.path(BATCH_ROOT, batch_name)
@@ -268,6 +303,8 @@ render_deval <- function(run_path, runid, config = NULL, skip_cache = FALSE, par
     append_log("INFO", glue("Cache bypass requested for run {runid}; regenerating report"))
   }
   append_log("INFO", glue("Starting render for run {runid}"))
+  local_fontawesome_header <- fontawesome_header()
+  on.exit(unlink(local_fontawesome_header, force = TRUE), add = TRUE)
   render_target <- output_file
   publish_after_render <- is.null(output_file_override)
   if (publish_after_render) {
@@ -285,6 +322,10 @@ render_deval <- function(run_path, runid, config = NULL, skip_cache = FALSE, par
         params = params,
         output_file = render_target,
         output_dir = dirname(render_target),
+        output_options = list(
+          use_fontawesome = FALSE,
+          includes = list(in_header = local_fontawesome_header)
+        ),
         # The production image has a read-only root filesystem. Keep all knit
         # intermediates in the pod-local writable tmpfs; only the fenced final
         # artifact is published to the run directory.

--- a/weppcloudR/templates/scripts/report.Rmd
+++ b/weppcloudR/templates/scripts/report.Rmd
@@ -5,7 +5,7 @@ output:
   cleanrmd::html_document_clean:
     theme: axist
     mathjax: default
-    use_fontawesome: true
+    use_fontawesome: false
     toc: true
     toc_float: true
 params:
@@ -505,4 +505,3 @@ merged_daily_df %>%
 # wbmap
 # wbtab
 ```
-

--- a/weppcloudR/templates/scripts/users/chinmay/comparative_report.Rmd
+++ b/weppcloudR/templates/scripts/users/chinmay/comparative_report.Rmd
@@ -7,7 +7,7 @@ output:
     fig_caption: true
     theme: axist
     mathjax: default
-    use_fontawesome: true
+    use_fontawesome: false
     toc: true
     toc_float: true
 params:

--- a/weppcloudR/templates/scripts/users/chinmay/comparative_report_input.Rmd
+++ b/weppcloudR/templates/scripts/users/chinmay/comparative_report_input.Rmd
@@ -7,7 +7,7 @@ output:
     fig_caption: true
     theme: axist
     mathjax: default
-    use_fontawesome: true
+    use_fontawesome: false
     toc: true
     toc_float: true
 params:

--- a/weppcloudR/templates/scripts/users/chinmay/new_report.Rmd
+++ b/weppcloudR/templates/scripts/users/chinmay/new_report.Rmd
@@ -8,7 +8,7 @@ output:
     fig_caption: true
     theme: axist
     mathjax: default
-    use_fontawesome: true
+    use_fontawesome: false
     toc: true
 params:
   proj_runid: default


### PR DESCRIPTION
Vendors Font Awesome Free 5.3.1 into the immutable WEPPcloudR image from its versioned HTTPS URL with exact SHA-256 verification, disables cleanrmd remote Font Awesome, and injects the verified local asset into self-contained reports. Extends the image contract to validate the asset with networking disabled and updates the renderer contract. Local checks: R parse PASS, checksum/header helper PASS in deployed R runtime, bash syntax, Python compile, git diff --check.