### PR TITLE
Publish tested fcgiwrap runtime image

### DIFF
--- a/.github/workflows/publish-weppcloud-aux-images.yml
+++ b/.github/workflows/publish-weppcloud-aux-images.yml
@@ -27,6 +27,13 @@ jobs:
           - service: weppcloudr
             image: weppcloudr
             dockerfile: weppcloudR/Dockerfile
+            build_args: ""
+          - service: fcgiwrap
+            image: wepppy-fcgiwrap
+            dockerfile: docker/Dockerfile.fcgiwrap
+            build_args: |
+              BASE_IMAGE=ghcr.io/rogerlew/wepppy@sha256:09614f07800bc4158df2fe0900370a39e0f5f960f536528716c2516d6fdb1920
+              APP_USER=roger
     steps:
       - name: Check out the dispatched source commit
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -65,6 +72,7 @@ jobs:
           labels: |
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+          build-args: ${{ matrix.build_args }}
 
       - name: Validate runtime contract before publication
         shell: bash

--- a/docker/validate-aux-image-contract.sh
+++ b/docker/validate-aux-image-contract.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 if [[ $# -ne 3 ]]; then
-  echo "usage: $0 <status|preflight|cap|weppcloudr> <image> <expected-revision>" >&2
+  echo "usage: $0 <status|preflight|cap|weppcloudr|fcgiwrap> <image> <expected-revision>" >&2
   exit 2
 fi
 
@@ -98,6 +98,17 @@ case "${service}" in
       "${image}" >/dev/null
     host_port=$(docker port "${container}" 8050/tcp | awk -F: 'END {print $NF}')
     wait_for_url "http://127.0.0.1:${host_port}/healthz"
+    ;;
+  fcgiwrap)
+    docker run --rm --network none --entrypoint /bin/sh "${image}" -lc '
+      set -eu
+      test "$(id -u)" = 1000
+      test "$(id -g)" = 993
+      test -x /usr/sbin/fcgiwrap
+      test -x /usr/bin/spawn-fcgi
+      test -x /usr/lib/git-core/git-http-backend
+      test "$(git config --system --get safe.directory)" = "*"
+    '
     ;;
   *)
     echo "unsupported service: ${service}" >&2


### PR DESCRIPTION
Adds the existing fcgiwrap runtime to the auxiliary GHCR pipeline using the immutable WEPPpy common image as its base, plus a non-networked runtime contract for UID/GID, FastCGI, Git backend, and safe-directory configuration. Compose files remain unchanged.