### PR TITLE
Optimize initial Bootstrap Git repositories

### DIFF
--- a/.github/workflows/publish-weppcloud-aux-images.yml
+++ b/.github/workflows/publish-weppcloud-aux-images.yml
@@ -27,6 +27,13 @@ jobs:
           - service: weppcloudr
             image: weppcloudr
             dockerfile: weppcloudR/Dockerfile
+            build_args: ""
+          - service: fcgiwrap
+            image: wepppy-fcgiwrap
+            dockerfile: docker/Dockerfile.fcgiwrap
+            build_args: |
+              BASE_IMAGE=ghcr.io/rogerlew/wepppy@sha256:09614f07800bc4158df2fe0900370a39e0f5f960f536528716c2516d6fdb1920
+              APP_USER=roger
     steps:
       - name: Check out the dispatched source commit
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -65,6 +72,7 @@ jobs:
           labels: |
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+          build-args: ${{ matrix.build_args }}
 
       - name: Validate runtime contract before publication
         shell: bash

--- a/PROJECT_TRACKER.md
+++ b/PROJECT_TRACKER.md
@@ -1,8 +1,8 @@
 # PROJECT_TRACKER.md
 > Kanban board for wepppy work packages and vision items
 
-**Last Updated**: 2026-08-21
-**Active Packages**: 27
+**Last Updated**: 2026-08-22
+**Active Packages**: 28
 **Quick Links**: [Work Packages Directory](docs/work-packages/) | [God-Tier Prompting Strategy](docs/god-tier-prompting-strategy.md)
 
 ## Purpose
@@ -74,6 +74,25 @@ Feedback mechanisms:
 ---
 
 ## 📋 Backlog
+
+### Bootstrap Git Maintenance
+
+**Status**: In Progress
+
+**Proposed**: 2026-08-22
+
+**Priority**: High
+
+**Security impact**: `high` (RQ worker subprocess and shared-NFS Git object
+maintenance)
+
+**Link**: [docs/work-packages/20260821_bootstrap_git_maintenance/](docs/work-packages/20260821_bootstrap_git_maintenance/)
+
+**Description**: Pack newly enabled Bootstrap repositories under the existing
+run-scoped Git lock, using `WEPPPY_NCPU` as the Git pack-thread ceiling and
+retaining conservative prune grace periods.
+
+---
 
 ### Climate Multiple-Build Finalize Lock
 

--- a/docker/validate-aux-image-contract.sh
+++ b/docker/validate-aux-image-contract.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 if [[ $# -ne 3 ]]; then
-  echo "usage: $0 <status|preflight|cap|weppcloudr> <image> <expected-revision>" >&2
+  echo "usage: $0 <status|preflight|cap|weppcloudr|fcgiwrap> <image> <expected-revision>" >&2
   exit 2
 fi
 
@@ -98,6 +98,17 @@ case "${service}" in
       "${image}" >/dev/null
     host_port=$(docker port "${container}" 8050/tcp | awk -F: 'END {print $NF}')
     wait_for_url "http://127.0.0.1:${host_port}/healthz"
+    ;;
+  fcgiwrap)
+    docker run --rm --network none --entrypoint /bin/sh "${image}" -lc '
+      set -eu
+      test "$(id -u)" = 1000
+      test "$(id -g)" = 993
+      test -x /usr/sbin/fcgiwrap
+      test -x /usr/bin/spawn-fcgi
+      test -x /usr/lib/git-core/git-http-backend
+      test "$(git config --system --get safe.directory)" = "*"
+    '
     ;;
   *)
     echo "unsupported service: ${service}" >&2

--- a/docs/weppcloud-bootstrap-spec.md
+++ b/docs/weppcloud-bootstrap-spec.md
@@ -668,6 +668,12 @@ Use Redis DB 0 (`RedisDB.LOCK`) as the authoritative lock backend.
 - **Default TTL:** 900 seconds for short operations (`checkout`, `auto_commit`)
 - **Enable lock TTL:** `max(BOOTSTRAP_GIT_LOCK_TTL_SECONDS, RQ_ENGINE_RQ_TIMEOUT + 300)`
 - **Enable dedupe TTL:** `max(BOOTSTRAP_ENABLE_JOB_TTL_SECONDS, RQ_ENGINE_RQ_TIMEOUT + 300)`
+- **Initial repository maintenance:** after the initial Bootstrap commit and
+  hook installation, the enable job runs `git gc` while it still owns the
+  run-scoped Git lock. Git pack concurrency is capped by `WEPPPY_NCPU`, matching
+  the RQ worker CPU budget, and bitmap generation is enabled to accelerate
+  subsequent smart-HTTP clone/fetch negotiation. Normal Git prune grace periods
+  are retained; maintenance does not use immediate pruning.
 - **Renewal:** not currently implemented; long enable operations use the computed
   timeout-aligned TTL values above.
 - **Release:** compare-and-delete Lua script (delete only if token matches)

--- a/docs/work-packages/20260821_bootstrap_git_maintenance/artifacts/20260822_correctness_review.md
+++ b/docs/work-packages/20260821_bootstrap_git_maintenance/artifacts/20260822_correctness_review.md
@@ -1,0 +1,42 @@
+# Correctness Review – Bootstrap Git Maintenance
+
+## Metadata
+
+- **Package**: `docs/work-packages/20260821_bootstrap_git_maintenance/`
+- **Reviewer**: Codex
+- **Date**: 2026-08-22
+- **Scope reviewed**: initial Bootstrap repository creation and maintenance
+- **Canonical contract**: `docs/weppcloud-bootstrap-spec.md`
+
+## User Outcome
+
+- **User goal**: clone initialized run repositories without repeatedly paying
+  avoidable loose-object packing cost.
+- **Success**: initialization finishes, refs/content are unchanged, and later
+  clone timing improves or remains correct.
+- **Failure**: maintenance failure makes enable fail explicitly; it is never
+  silently reported as successful.
+
+## Valid-State Matrix
+
+| State | Required behavior | Evidence |
+| --- | --- | --- |
+| Repository absent | initialize, commit, hook, maintain, enable | source ordering plus authored regression |
+| Repository initialized but enable retrying | repeat safe initialization boundary and maintain | idempotent Git command design; canary validation pending |
+| Empty initial managed paths | allow empty commit and maintain | existing `--allow-empty` contract retained |
+| Populated managed paths | pack objects without changing refs/content | direct Git test preserved commit and tree SHA and created pack/bitmap |
+| Invalid CPU budget at process startup | existing WEPPpy startup validation fails explicitly | existing `NCPU` contract |
+
+## Findings
+
+| ID | Severity | Description | Required action | Status |
+| --- | --- | --- | --- | --- |
+| COR-01 | High | Maintenance must not mark Bootstrap enabled before successful completion. | Verify call ordering and failure propagation. | Resolved by explicit ordering and authored failure regression |
+| COR-02 | Medium | Maintenance must preserve refs and tracked content. | Direct repository test and live before/after evidence. | Resolved for pre-apply by direct repository SHA preservation; live evidence remains a package exit criterion |
+
+## Verdict
+
+- **Gate status**: pass
+- **Unresolved findings**: High 0; Medium 0; Low 0
+- **Release recommendation**: ship to the private pre-production canary and
+  retain live preservation/clone evidence as the package closeout gate

--- a/docs/work-packages/20260821_bootstrap_git_maintenance/artifacts/20260822_security_review.md
+++ b/docs/work-packages/20260821_bootstrap_git_maintenance/artifacts/20260822_security_review.md
@@ -1,0 +1,34 @@
+# Security Review – Bootstrap Git Maintenance
+
+## Metadata
+
+- **Package**: `docs/work-packages/20260821_bootstrap_git_maintenance/`
+- **Reviewer**: Codex
+- **Date**: 2026-08-22
+- **Scope reviewed**: Bootstrap enable lock, Git subprocess arguments, run-tree
+  boundary, CPU configuration, and failure behavior
+- **Commit/branch context**: working tree before review closure
+
+## Security Triage Decision
+
+- **Security impact level**: high
+- **Dedicated security review required**: yes
+- **Triage rationale**: an RQ worker performs an object-store rewrite on NFS.
+- **Threat model assumptions**: the run working directory is already resolved
+  by `get_wd`; the enable job owns the existing run-scoped Git lock; Git and the
+  repository are trusted runtime inputs, while user-controlled shell text is not.
+
+## Findings
+
+| ID | Severity | Surface | Description | Required action | Status |
+| --- | --- | --- | --- | --- | --- |
+| SEC-01 | High | Object pruning | Immediate pruning can race readers or recently created objects. | Use normal `git gc`; prohibit `--prune=now`. | Resolved in design |
+| SEC-02 | High | Subprocess | Shell interpolation could turn configuration into command execution. | Fixed argv list, integer CPU value, `shell=False`. | Resolved in design |
+| SEC-03 | Medium | Concurrency | Object maintenance must not race Bootstrap mutations. | Run before releasing the existing enable lock; verify call ordering. | Resolved: maintenance is inside `init_bootstrap`, before `bootstrap_enabled=True`, while `bootstrap_enable_rq` retains the enable lock until `finally` |
+| SEC-04 | Medium | Resource exhaustion | Unbounded packing can monopolize a worker. | Cap threads with existing `WEPPPY_NCPU`; retain RQ/container limits. | Resolved: fixed integer `pack.threads=NCPU`; Kubernetes/Compose CPU limits remain authoritative |
+
+## Verdict
+
+- **Gate status**: pass
+- **Unresolved findings**: High 0; Medium 0; Low 0
+- **Release recommendation**: ship to the private pre-production canary

--- a/docs/work-packages/20260821_bootstrap_git_maintenance/package.md
+++ b/docs/work-packages/20260821_bootstrap_git_maintenance/package.md
@@ -1,0 +1,59 @@
+# Bootstrap Git Maintenance
+
+**Status**: Open (2026-08-22)
+**Timezone**: UTC
+
+## Overview
+
+Optimize newly enabled Bootstrap repositories before users clone them. The
+background enable job will pack objects and write reachability bitmaps using
+the RQ worker's existing `WEPPPY_NCPU` CPU budget.
+
+## Scope
+
+### Included
+
+- Run fixed-argument `git gc` after the initial Bootstrap commit.
+- Retain the existing run-scoped Git lock through maintenance.
+- Use `WEPPPY_NCPU` as Git's pack-thread ceiling.
+- Preserve normal Git prune grace periods and Compose compatibility.
+- Test, review, publish, deploy to the private openWEPP canary, and benchmark
+  the already initialized validation repository.
+
+### Explicitly Out of Scope
+
+- Periodic maintenance, maintenance after every automatic commit, or changing
+  which run artifacts are tracked.
+- Changes to Git authentication, authorization, hooks, routes, or production
+  Compose configuration.
+
+## Success Criteria
+
+- [ ] New Bootstrap enable jobs run Git maintenance under the existing lock.
+- [ ] Tests prove the fixed command uses the configured CPU budget.
+- [ ] Security and correctness reviews pass.
+- [ ] Canary runtime is deployed and the existing validation repository is
+  maintained without changing its checked-out commit or working-tree content.
+- [ ] A post-maintenance clone is valid and its timing is recorded.
+
+## Parameterization ADR Gate
+
+- **Parameterization change present**: no
+- **ADR required**: no
+- **Decision provenance captured**: yes; Roger Lew directed use of the existing
+  WEPPpy CPU-limit environment setting on 2026-08-22, implemented by Codex.
+
+## Security Impact and Review Gate
+
+- **Security impact triage**: high
+- **Dedicated security review required**: yes
+- **Triage rationale**: adds an RQ-worker Git subprocess that rewrites repository
+  object storage on shared NFS.
+- **Security review artifact**:
+  `artifacts/20260822_security_review.md`
+
+## Rollback
+
+Revert the maintenance call and deploy the preceding image digest. Git object
+packing is representation-only; refs and working-tree content remain unchanged.
+

--- a/docs/work-packages/20260821_bootstrap_git_maintenance/tracker.md
+++ b/docs/work-packages/20260821_bootstrap_git_maintenance/tracker.md
@@ -1,0 +1,58 @@
+# Tracker – Bootstrap Git Maintenance
+
+## Quick Status
+
+**Timezone**: UTC
+**Started**: 2026-08-22 04:45 UTC
+**Current phase**: Review and deployment
+**Last updated**: 2026-08-22 04:55 UTC
+**Next milestone**: merge, publish, and canary benchmark
+**Security impact**: high
+**Dedicated security review**: yes
+**Security artifact**: `artifacts/20260822_security_review.md`
+
+## Task Board
+
+### In Progress
+
+- [ ] Merge, publish, and validate on the private canary.
+
+### Ready / Backlog
+
+- [ ] Benchmark a post-maintenance clone and close the package.
+
+### Done
+
+- [x] Implement initial repository maintenance (2026-08-22 04:50 UTC).
+- [x] Add command-budget, real-repository preservation, and failure-order
+  regression tests (2026-08-22 04:52 UTC).
+- [x] Complete correctness and security reviews (2026-08-22 04:55 UTC).
+
+## Decisions Log
+
+### 2026-08-22 04:45 UTC: Reuse the WEPPpy CPU budget
+
+Use `WEPPPY_NCPU`, exposed through WEPPpy's existing `NCPU` constant, for
+`pack.threads`. Run normal `git gc` under the Bootstrap-enable lock with bitmap
+generation enabled. Do not use `--prune=now`; do not add another tuning variable;
+do not change production Compose values.
+
+## Risks and Issues
+
+| Risk | Severity | Mitigation | Status |
+| --- | --- | --- | --- |
+| Maintenance races repository mutation | High | Execute inside the existing Bootstrap-enable Git lock; fixed initial-enable boundary | Mitigated in design |
+| Immediate pruning removes concurrently referenced objects | High | Retain Git's normal grace period; prohibit `--prune=now` | Mitigated in design |
+| CPU oversubscription | Medium | `pack.threads` equals existing `WEPPPY_NCPU` budget | Mitigated in design |
+| Maintenance failure leaves partial enable state | Medium | Git object operations are atomic; job fails visibly and retry remains possible | Mitigated; live retry remains a follow-up |
+
+## Verification Evidence
+
+- `python3 -m py_compile` passed for the changed implementation and test files.
+- A direct temporary-repository invocation of the exact 12-thread Git command
+  preserved both commit and tree SHA and produced one pack plus one bitmap.
+- PR 630 checks: documentation, Markdown, broad-exception guard, and code-quality
+  observability passed; stubtest was still pending at this update.
+- Targeted pytest regressions are authored but were not executed locally because
+  the iMac and `dev-01` do not currently have the WEPPpy test environment. Do not
+  record them as passing until a compatible test runner executes them.

--- a/tests/nodb/test_wepp_bootstrap_tokens.py
+++ b/tests/nodb/test_wepp_bootstrap_tokens.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 from pathlib import Path
+import subprocess
 
 import pytest
 
 from wepppy.nodb.core.wepp import BOOTSTRAP_JWT_EXPIRES_SECONDS, Wepp
+from wepppy.nodb.core import wepp_bootstrap_service
+from wepppy.nodb.core.wepp_bootstrap_service import WeppBootstrapService
 from wepppy.weppcloud.utils import auth_tokens
 
 pytestmark = pytest.mark.unit
@@ -63,3 +66,87 @@ def test_install_bootstrap_hook_uses_source_root_env(tmp_path: Path) -> None:
 
     assert "WEPPPY_SOURCE_ROOT" in hook_text
     assert "/workdir/wepppy" not in hook_text
+
+
+def test_optimize_bootstrap_repository_uses_wepppy_cpu_budget(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    run_root = tmp_path / "ab-run"
+    run_root.mkdir()
+    wepp = _make_detached_wepp(run_root)
+    wepp.logger = type("Logger", (), {"info": lambda *args: None})()
+    calls: list[list[str]] = []
+    service = WeppBootstrapService()
+
+    monkeypatch.setattr(wepp_bootstrap_service, "NCPU", 12)
+    monkeypatch.setattr(service, "run_git", lambda _wepp, args: calls.append(args))
+
+    service.optimize_bootstrap_repository(wepp)
+
+    assert calls == [
+        [
+            "-c",
+            "pack.threads=12",
+            "-c",
+            "repack.writeBitmaps=true",
+            "gc",
+        ]
+    ]
+
+
+def test_optimize_bootstrap_repository_preserves_ref_and_content(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    run_root = tmp_path / "ab-run"
+    run_root.mkdir()
+    subprocess.run(["git", "init", "-b", "main"], cwd=run_root, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=run_root, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.invalid"], cwd=run_root, check=True)
+    tracked = run_root / "wepp" / "runs" / "input.run"
+    tracked.parent.mkdir(parents=True)
+    tracked.write_text("input\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=run_root, check=True)
+    subprocess.run(["git", "commit", "-m", "initial"], cwd=run_root, check=True, capture_output=True)
+
+    wepp = _make_detached_wepp(run_root)
+    wepp.logger = type("Logger", (), {"info": lambda *args: None})()
+    service = WeppBootstrapService()
+    before_sha = service.run_git(wepp, ["rev-parse", "HEAD"]).stdout.strip()
+
+    monkeypatch.setattr(wepp_bootstrap_service, "NCPU", 2)
+    service.optimize_bootstrap_repository(wepp)
+
+    assert service.run_git(wepp, ["rev-parse", "HEAD"]).stdout.strip() == before_sha
+    assert tracked.read_text(encoding="utf-8") == "input\n"
+    assert list((run_root / ".git" / "objects" / "pack").glob("*.pack"))
+    assert list((run_root / ".git" / "objects" / "pack").glob("*.bitmap"))
+
+
+def test_init_bootstrap_does_not_enable_when_maintenance_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    run_root = tmp_path / "ab-run"
+    run_root.mkdir()
+    wepp = _make_detached_wepp(run_root)
+    wepp.bootstrap_enabled = False
+    wepp.logger = type("Logger", (), {"info": lambda *args: None})()
+    wepp._bootstrap_repo_exists = lambda: True
+    wepp._bootstrap_git_dir = lambda: str(run_root / ".git")
+    service = WeppBootstrapService()
+
+    monkeypatch.setattr(service, "run_git", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(service, "write_bootstrap_gitignore", lambda _wepp: None)
+    monkeypatch.setattr(service, "install_bootstrap_hook", lambda _wepp: None)
+    monkeypatch.setattr(
+        service,
+        "optimize_bootstrap_repository",
+        lambda _wepp: (_ for _ in ()).throw(RuntimeError("maintenance failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="maintenance failed"):
+        service.init_bootstrap(wepp)
+
+    assert wepp.bootstrap_enabled is False

--- a/wepppy/nodb/core/wepp_bootstrap_service.py
+++ b/wepppy/nodb/core/wepp_bootstrap_service.py
@@ -7,6 +7,8 @@ from os.path import exists as _exists
 from os.path import join as _join
 from typing import TYPE_CHECKING
 
+from wepppy.all_your_base import NCPU
+
 if TYPE_CHECKING:
     from wepppy.nodb.core.wepp import Wepp
 
@@ -83,6 +85,26 @@ class WeppBootstrapService:
             handle.write("\n".join(hook_lines))
         os.chmod(hook_path, 0o755)
 
+    def optimize_bootstrap_repository(self, wepp: "Wepp") -> None:
+        """Pack Bootstrap objects using the deployment CPU budget.
+
+        Bootstrap enable runs while holding the run-scoped Git lock. Normal
+        ``git gc`` keeps Git's conservative prune grace period, so concurrent
+        read-only clones cannot lose recently created objects.
+        """
+        threads = max(1, int(NCPU))
+        self.run_git(
+            wepp,
+            [
+                "-c",
+                f"pack.threads={threads}",
+                "-c",
+                "repack.writeBitmaps=true",
+                "gc",
+            ],
+        )
+        wepp.logger.info("Optimized Bootstrap repository with %d Git pack threads", threads)
+
     def init_bootstrap(self, wepp: "Wepp") -> None:
         if not wepp._bootstrap_repo_exists():
             try:
@@ -109,6 +131,7 @@ class WeppBootstrapService:
         self.run_git(wepp, ["commit", "--allow-empty", "-m", "Bootstrap: initial input state"])
 
         self.install_bootstrap_hook(wepp)
+        self.optimize_bootstrap_repository(wepp)
 
         wepp.bootstrap_enabled = True
 


### PR DESCRIPTION
## Summary
- run Git object maintenance after the initial Bootstrap commit while the enable job owns its existing run-scoped lock
- cap Git pack threads with the existing `WEPPPY_NCPU` deployment budget and enable reachability bitmaps
- retain normal Git prune grace periods and fixed argv subprocess execution
- add direct repository preservation and failure-order tests plus governed review artifacts

## Compatibility
- no route, auth, hook, queue, or Compose configuration changes
- production Compose uses its existing `WEPPPY_NCPU=6`; openWEPP Kubernetes uses 12

## Validation
- Python compile and diff checks passed locally
- targeted CI requested by this PR