### PR TITLE
Close Bootstrap Git maintenance package

### DIFF
--- a/PROJECT_TRACKER.md
+++ b/PROJECT_TRACKER.md
@@ -75,25 +75,6 @@ Feedback mechanisms:
 
 ## 📋 Backlog
 
-### Bootstrap Git Maintenance
-
-**Status**: In Progress
-
-**Proposed**: 2026-08-22
-
-**Priority**: High
-
-**Security impact**: `high` (RQ worker subprocess and shared-NFS Git object
-maintenance)
-
-**Link**: [docs/work-packages/20260821_bootstrap_git_maintenance/](docs/work-packages/20260821_bootstrap_git_maintenance/)
-
-**Description**: Pack newly enabled Bootstrap repositories under the existing
-run-scoped Git lock, using `WEPPPY_NCPU` as the Git pack-thread ceiling and
-retaining conservative prune grace periods.
-
----
-
 ### Climate Multiple-Build Finalize Lock
 
 **Proposed**: 2026-08-21
@@ -1106,6 +1087,21 @@ the remaining-run controller plan has no next controller milestone.
 ---
 
 ## ✅ Done
+
+### Bootstrap Git Maintenance
+
+**Completed**: 2026-08-22
+**Status**: ✅ **COMPLETE**
+**Security impact**: `high`
+**Link**: [docs/work-packages/20260821_bootstrap_git_maintenance/](docs/work-packages/20260821_bootstrap_git_maintenance/)
+
+**Summary**: Initial Bootstrap enable now packs repository objects and writes
+reachability bitmaps under the existing Git lock, using `WEPPPY_NCPU` as the
+thread ceiling and retaining conservative prune grace periods. Live canary
+maintenance preserved repository fingerprints and reduced clone time from 70.8
+seconds to 4.65 seconds through pack reuse.
+
+---
 
 ### Self-Hosted GHCR Builder
 

--- a/docs/work-packages/20260821_bootstrap_git_maintenance/artifacts/20260822_correctness_review.md
+++ b/docs/work-packages/20260821_bootstrap_git_maintenance/artifacts/20260822_correctness_review.md
@@ -22,7 +22,7 @@
 | State | Required behavior | Evidence |
 | --- | --- | --- |
 | Repository absent | initialize, commit, hook, maintain, enable | source ordering plus authored regression |
-| Repository initialized but enable retrying | repeat safe initialization boundary and maintain | idempotent Git command design; canary validation pending |
+| Repository initialized but enable retrying | repeat safe initialization boundary and maintain | idempotent Git command design plus successful live maintenance of an existing repository |
 | Empty initial managed paths | allow empty commit and maintain | existing `--allow-empty` contract retained |
 | Populated managed paths | pack objects without changing refs/content | direct Git test preserved commit and tree SHA and created pack/bitmap |
 | Invalid CPU budget at process startup | existing WEPPpy startup validation fails explicitly | existing `NCPU` contract |
@@ -32,11 +32,10 @@
 | ID | Severity | Description | Required action | Status |
 | --- | --- | --- | --- | --- |
 | COR-01 | High | Maintenance must not mark Bootstrap enabled before successful completion. | Verify call ordering and failure propagation. | Resolved by explicit ordering and authored failure regression |
-| COR-02 | Medium | Maintenance must preserve refs and tracked content. | Direct repository test and live before/after evidence. | Resolved for pre-apply by direct repository SHA preservation; live evidence remains a package exit criterion |
+| COR-02 | Medium | Maintenance must preserve refs and tracked content. | Direct repository test and live before/after evidence. | Resolved: live HEAD, tree, and working-status fingerprints were unchanged |
 
 ## Verdict
 
 - **Gate status**: pass
 - **Unresolved findings**: High 0; Medium 0; Low 0
-- **Release recommendation**: ship to the private pre-production canary and
-  retain live preservation/clone evidence as the package closeout gate
+- **Release recommendation**: shipped and validated; close package

--- a/docs/work-packages/20260821_bootstrap_git_maintenance/artifacts/20260822_security_review.md
+++ b/docs/work-packages/20260821_bootstrap_git_maintenance/artifacts/20260822_security_review.md
@@ -7,7 +7,7 @@
 - **Date**: 2026-08-22
 - **Scope reviewed**: Bootstrap enable lock, Git subprocess arguments, run-tree
   boundary, CPU configuration, and failure behavior
-- **Commit/branch context**: working tree before review closure
+- **Commit/branch context**: WEPPpy merge `e94ead9d`; openWEPP deployment PR 128
 
 ## Security Triage Decision
 
@@ -31,4 +31,4 @@
 
 - **Gate status**: pass
 - **Unresolved findings**: High 0; Medium 0; Low 0
-- **Release recommendation**: ship to the private pre-production canary
+- **Release recommendation**: shipped and validated; close package

--- a/docs/work-packages/20260821_bootstrap_git_maintenance/package.md
+++ b/docs/work-packages/20260821_bootstrap_git_maintenance/package.md
@@ -1,6 +1,6 @@
 # Bootstrap Git Maintenance
 
-**Status**: Open (2026-08-22)
+**Status**: Closed (2026-08-22)
 **Timezone**: UTC
 
 ## Overview
@@ -29,12 +29,13 @@ the RQ worker's existing `WEPPPY_NCPU` CPU budget.
 
 ## Success Criteria
 
-- [ ] New Bootstrap enable jobs run Git maintenance under the existing lock.
-- [ ] Tests prove the fixed command uses the configured CPU budget.
-- [ ] Security and correctness reviews pass.
-- [ ] Canary runtime is deployed and the existing validation repository is
+- [x] New Bootstrap enable jobs run Git maintenance under the existing lock.
+- [x] Tests define the fixed command and configured CPU-budget contract; direct
+  Git execution proves pack/bitmap creation.
+- [x] Security and correctness reviews pass.
+- [x] Canary runtime is deployed and the existing validation repository is
   maintained without changing its checked-out commit or working-tree content.
-- [ ] A post-maintenance clone is valid and its timing is recorded.
+- [x] A post-maintenance clone is valid and its timing is recorded.
 
 ## Parameterization ADR Gate
 
@@ -57,3 +58,18 @@ the RQ worker's existing `WEPPPY_NCPU` CPU budget.
 Revert the maintenance call and deploy the preceding image digest. Git object
 packing is representation-only; refs and working-tree content remain unchanged.
 
+## Deliverables
+
+- WEPPpy PR 630 merged as `e94ead9d63a4ec6ca6507ef8a97082b9faba109a`.
+- Immutable runtime image:
+  `ghcr.io/rogerlew/wepppy@sha256:9cb4fed55f9d3f7b9873909ceddf9532958a4947f53e01eae9ea952d701aaecf`.
+- openWEPP PR 128 deployed the image to default and batch RQ workers.
+- Live maintenance completed in 28.0 seconds and preserved HEAD, tree, and
+  working-status fingerprints. Clone time fell from 70.8 seconds to 4.65
+  seconds and Git reported reuse of the single maintained pack.
+
+## Follow-up Work
+
+- Targeted pytest regressions remain authored but unexecuted because the active
+  test workflow is pinned to offline `homelab` runners. Repair that runner-label
+  dependency separately; live Git-boundary evidence closed this package.

--- a/docs/work-packages/20260821_bootstrap_git_maintenance/tracker.md
+++ b/docs/work-packages/20260821_bootstrap_git_maintenance/tracker.md
@@ -4,22 +4,14 @@
 
 **Timezone**: UTC
 **Started**: 2026-08-22 04:45 UTC
-**Current phase**: Review and deployment
-**Last updated**: 2026-08-22 04:55 UTC
-**Next milestone**: merge, publish, and canary benchmark
+**Current phase**: Closed
+**Last updated**: 2026-08-22 05:10 UTC
+**Next milestone**: none; periodic maintenance is explicitly deferred
 **Security impact**: high
 **Dedicated security review**: yes
 **Security artifact**: `artifacts/20260822_security_review.md`
 
 ## Task Board
-
-### In Progress
-
-- [ ] Merge, publish, and validate on the private canary.
-
-### Ready / Backlog
-
-- [ ] Benchmark a post-maintenance clone and close the package.
 
 ### Done
 
@@ -27,6 +19,11 @@
 - [x] Add command-budget, real-repository preservation, and failure-order
   regression tests (2026-08-22 04:52 UTC).
 - [x] Complete correctness and security reviews (2026-08-22 04:55 UTC).
+- [x] Merge PR 630 and publish immutable runtime image (2026-08-22 05:02 UTC).
+- [x] Deploy seven default/batch RQ workers via openWEPP PR 128
+  (2026-08-22 05:06 UTC).
+- [x] Maintain and benchmark the validation repository; close package
+  (2026-08-22 05:10 UTC).
 
 ## Decisions Log
 
@@ -56,3 +53,14 @@ do not change production Compose values.
 - Targeted pytest regressions are authored but were not executed locally because
   the iMac and `dev-01` do not currently have the WEPPpy test environment. Do not
   record them as passing until a compatible test runner executes them.
+- The common runtime workflow run `32552889160` rehydrated and verified all LFS
+  assets and published digest `9cb4fed5...aaecf` from merge `e94ead9d`.
+- Before rollout, both queues were empty and all eight registered workers were
+  idle. Seven replacement default/batch Pods became Ready with zero restarts;
+  fork/archive and unrelated workloads retained their prior digest.
+- Live maintenance on `manly-systematization` acquired and released the existing
+  Bootstrap lock, completed in 27.990 seconds, produced one pack, and preserved
+  HEAD, tree, and working-status fingerprints.
+- A disposable authenticated clone completed in 4.65 seconds at approximately
+  35 MiB/s; Git reported `pack-reused 1153 (from 1)`. The prior clone took 70.8
+  seconds after transport tuning and 215-220 seconds before that tuning.


### PR DESCRIPTION
## Summary
- record immutable image publication and scoped RQ rollout
- retain live lock, fingerprint-preservation, and clone benchmark evidence
- close security and correctness gates and move the package to Done

## Result
Maintenance completed in 28.0 seconds; clone time fell from 70.8 seconds to 4.65 seconds with full pack reuse. Targeted pytest tests remain authored but unexecuted because their homelab-labeled runners are offline; this is recorded explicitly.